### PR TITLE
feat: replace SQLite request cache with DynamoDB/memory backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,17 +8,15 @@ BGG_RETRY_DELAY=10
 BGG_RETRIES=6
 
 # Cache Configuration
-ITEM_CACHE_DURATION=86400  # 1 day in seconds
-GAME_CACHE_DURATION=604800  # 1 week in seconds
+REQUEST_CACHE_DURATION=86400  # 1 day in seconds (collections, searches)
+GAME_CACHE_DURATION=604800  # 1 week in seconds (individual game data)
 
-# Cache Backend: 'dynamodb' or 'sqlite'
+# Cache Backend: 'dynamodb' (AWS) or 'memory' (local dev, lost on restart)
 CACHE_BACKEND=dynamodb
 
-# SQLite Configuration (for local development)
-SQLITE_CACHE_FILE=cache.db
-
 # DynamoDB Configuration (for production)
-DYNAMODB_TABLE_NAME=bgg-game-cache
+DYNAMODB_REQUEST_TABLE=bgg-request-cache
+DYNAMODB_GAME_TABLE=bgg-game-cache
 AWS_REGION=us-east-1
 
 # AWS Credentials (if not using IAM roles)

--- a/boardgame/board_game.py
+++ b/boardgame/board_game.py
@@ -1,7 +1,7 @@
 import abc
 from typing import List
 
-from boardgamegeek import BGGClient, CacheBackendSqlite, BGGItemNotFoundError
+from boardgamegeek import BGGClient, BGGItemNotFoundError
 from boardgamegeek.objects.games import BaseGame, BoardGame
 from werkzeug.datastructures import EnvironHeaders
 
@@ -9,6 +9,10 @@ from boardgame import filter_processor
 from boardgame.field_reduction import FieldReduction
 from boardgame.game_cache import GameCache, SQLiteGameCache, DynamoDBGameCache
 from boardgame.legacy_api import BGGClientLegacy
+from boardgame.request_cache import (
+    CacheRequestBackendDynamoDB,
+    CacheRequestBackendMemory,
+)
 from config import Config
 
 
@@ -26,12 +30,21 @@ class BoardGameListNotFoundError(Exception):
 class BoardGameFactory(object):
 
     @staticmethod
+    def create_request_cache():
+        if Config.CACHE_BACKEND == "dynamodb":
+            return CacheRequestBackendDynamoDB(
+                table_name=Config.DYNAMODB_REQUEST_TABLE,
+                ttl=Config.REQUEST_CACHE_DURATION,
+                region=Config.DYNAMODB_REGION,
+            )
+        else:
+            return CacheRequestBackendMemory(ttl=Config.REQUEST_CACHE_DURATION)
+
+    @staticmethod
     def create_client():
         return BGGClient(
             access_token=Config.BGG_ACCESS_TOKEN,
-            cache=CacheBackendSqlite(
-                path=Config.SQLITE_CACHE_FILE, ttl=Config.ITEM_CACHE_DURATION
-            ),
+            cache=BoardGameFactory.create_request_cache(),
             timeout=Config.BGG_TIMEOUT,
             retry_delay=Config.BGG_RETRY_DELAY,
             retries=Config.BGG_RETRIES,
@@ -40,9 +53,7 @@ class BoardGameFactory(object):
     @staticmethod
     def create_legacy_client():
         return BGGClientLegacy(
-            cache=CacheBackendSqlite(
-                path=Config.SQLITE_CACHE_FILE, ttl=Config.ITEM_CACHE_DURATION
-            ),
+            cache=BoardGameFactory.create_request_cache(),
             timeout=Config.BGG_TIMEOUT,
             retry_delay=Config.BGG_RETRY_DELAY,
             retries=Config.BGG_RETRIES,
@@ -50,10 +61,9 @@ class BoardGameFactory(object):
 
     @staticmethod
     def create_game_cache() -> GameCache:
-        """Create game cache based on configuration"""
         if Config.CACHE_BACKEND == "dynamodb":
             return DynamoDBGameCache(
-                table_name=Config.DYNAMODB_TABLE_NAME,
+                table_name=Config.DYNAMODB_GAME_TABLE,
                 cache_length_seconds=Config.GAME_CACHE_DURATION,
                 region=Config.DYNAMODB_REGION,
             )

--- a/boardgame/request_cache.py
+++ b/boardgame/request_cache.py
@@ -1,0 +1,95 @@
+import logging
+import time
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+class CacheRequestBackendDynamoDB:
+    def __init__(self, table_name: str, ttl: int, region: str = "us-east-1"):
+        self.table_name = table_name
+        self.ttl = ttl
+        self.region = region
+        self._dynamodb = None
+        self._table = None
+
+    @property
+    def dynamodb(self):
+        if self._dynamodb is None:
+            self._dynamodb = boto3.resource("dynamodb", region_name=self.region)
+        return self._dynamodb
+
+    @property
+    def table(self):
+        if self._table is None:
+            self._table = self.dynamodb.Table(self.table_name)
+        return self._table
+
+    def get(self, key: str) -> Optional[str]:
+        try:
+            response = self.table.get_item(Key={"id": f"request_{key}"})
+            item = response.get("Item")
+
+            if not item:
+                return None
+
+            ttl = item.get("ttl", 0)
+            if ttl > 0 and ttl < int(time.time()):
+                return None
+
+            return item.get("data")
+
+        except ClientError as e:
+            logger.error(f"Error getting cache key {key}: {e}")
+            return None
+
+    def set(self, key: str, value: str):
+        try:
+            ttl_timestamp = int(time.time()) + self.ttl
+            self.table.put_item(
+                Item={"id": f"request_{key}", "data": value, "ttl": ttl_timestamp}
+            )
+        except ClientError as e:
+            logger.error(f"Error setting cache key {key}: {e}")
+
+    def delete(self, key: str):
+        try:
+            self.table.delete_item(Key={"id": f"request_{key}"})
+        except ClientError as e:
+            logger.error(f"Error deleting cache key {key}: {e}")
+
+    def clear(self):
+        pass
+
+
+class CacheRequestBackendMemory:
+    def __init__(self, ttl: int):
+        self.ttl = ttl
+        self._cache = {}
+        self._timestamps = {}
+
+    def get(self, key: str) -> Optional[str]:
+        if key not in self._cache:
+            return None
+
+        if self._timestamps.get(key, 0) < time.time():
+            del self._cache[key]
+            del self._timestamps[key]
+            return None
+
+        return self._cache[key]
+
+    def set(self, key: str, value: str):
+        self._cache[key] = value
+        self._timestamps[key] = time.time() + self.ttl
+
+    def delete(self, key: str):
+        self._cache.pop(key, None)
+        self._timestamps.pop(key, None)
+
+    def clear(self):
+        self._cache.clear()
+        self._timestamps.clear()

--- a/config.py
+++ b/config.py
@@ -6,25 +6,21 @@ load_dotenv()
 
 class Config:
     # BGG API Configuration
-    BGG_ACCESS_TOKEN = os.getenv(
-        "BGG_ACCESS_TOKEN", ""
-    )  # Empty string for anonymous access
+    BGG_ACCESS_TOKEN = os.getenv("BGG_ACCESS_TOKEN", "")
     BGG_TIMEOUT = int(os.getenv("BGG_TIMEOUT", "60"))
     BGG_RETRY_DELAY = int(os.getenv("BGG_RETRY_DELAY", "10"))
     BGG_RETRIES = int(os.getenv("BGG_RETRIES", "6"))
 
     # Cache Configuration
-    ITEM_CACHE_DURATION = int(os.getenv("ITEM_CACHE_DURATION", "86400"))  # 1 day
+    REQUEST_CACHE_DURATION = int(os.getenv("REQUEST_CACHE_DURATION", "86400"))  # 1 day
     GAME_CACHE_DURATION = int(os.getenv("GAME_CACHE_DURATION", "604800"))  # 1 week
 
     # Cache Backend Selection
-    CACHE_BACKEND = os.getenv("CACHE_BACKEND", "dynamodb")  # 'dynamodb' or 'sqlite'
+    CACHE_BACKEND = os.getenv("CACHE_BACKEND", "dynamodb")  # 'dynamodb' or 'memory'
 
-    # SQLite Configuration (for local development)
-    SQLITE_CACHE_FILE = os.getenv("SQLITE_CACHE_FILE", "cache.db")
-
-    # DynamoDB Configuration (for production)
-    DYNAMODB_TABLE_NAME = os.getenv("DYNAMODB_TABLE_NAME", "bgg-game-cache")
+    # DynamoDB Configuration
+    DYNAMODB_REQUEST_TABLE = os.getenv("DYNAMODB_REQUEST_TABLE", "bgg-request-cache")
+    DYNAMODB_GAME_TABLE = os.getenv("DYNAMODB_GAME_TABLE", "bgg-game-cache")
     DYNAMODB_REGION = os.getenv("AWS_REGION", "us-east-1")
 
     # Flask Configuration
@@ -32,11 +28,10 @@ class Config:
 
     @staticmethod
     def validate():
-        """Validate required configuration is present"""
         if Config.CACHE_BACKEND == "dynamodb":
-            required = ["DYNAMODB_TABLE_NAME"]
+            required = ["DYNAMODB_REQUEST_TABLE", "DYNAMODB_GAME_TABLE"]
             missing = [var for var in required if not os.getenv(var)]
             if missing:
                 print(f"Warning: Missing DynamoDB configuration: {', '.join(missing)}")
-                print("Falling back to SQLite cache")
-                Config.CACHE_BACKEND = "sqlite"
+                print("Falling back to in-memory cache")
+                Config.CACHE_BACKEND = "memory"

--- a/deployment/cloudformation-template.yaml
+++ b/deployment/cloudformation-template.yaml
@@ -38,7 +38,30 @@ Parameters:
     AllowedValues: [512, 1024, 2048, 4096, 8192]
 
 Resources:
-  # DynamoDB Table for game cache
+  # DynamoDB Table for request cache (collections, searches)
+  RequestCacheTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${EnvironmentName}-bgg-request-cache
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Application
+          Value: bgg-game-selector
+        - Key: CacheType
+          Value: request-cache
+
+  # DynamoDB Table for game cache (individual game data)
   GameCacheTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -58,7 +81,7 @@ Resources:
           Value: !Ref EnvironmentName
         - Key: Application
           Value: bgg-game-selector
-        - Key: Purpose
+        - Key: CacheType
           Value: game-cache
 
   # ECS Cluster
@@ -119,7 +142,9 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:DescribeTable
                   - dynamodb:DescribeTimeToLive
-                Resource: !GetAtt GameCacheTable.Arn
+                Resource:
+                  - !GetAtt RequestCacheTable.Arn
+                  - !GetAtt GameCacheTable.Arn
 
   # ECS Task Definition
   TaskDefinition:
@@ -143,7 +168,9 @@ Resources:
           Environment:
             - Name: CACHE_BACKEND
               Value: dynamodb
-            - Name: DYNAMODB_TABLE_NAME
+            - Name: DYNAMODB_REQUEST_TABLE
+              Value: !Ref RequestCacheTable
+            - Name: DYNAMODB_GAME_TABLE
               Value: !Ref GameCacheTable
             - Name: AWS_REGION
               Value: !Ref AWS::Region
@@ -153,7 +180,7 @@ Resources:
               Value: '60'
             - Name: BGG_RETRIES
               Value: '6'
-            - Name: ITEM_CACHE_DURATION
+            - Name: REQUEST_CACHE_DURATION
               Value: '86400'
             - Name: GAME_CACHE_DURATION
               Value: '604800'
@@ -277,11 +304,17 @@ Outputs:
     Export:
       Name: !Sub ${EnvironmentName}-bgg-api-url
 
-  DynamoDBTableName:
+  DynamoDBRequestTableName:
+    Description: DynamoDB table name for request cache
+    Value: !Ref RequestCacheTable
+    Export:
+      Name: !Sub ${EnvironmentName}-bgg-request-cache-table
+
+  DynamoDBGameTableName:
     Description: DynamoDB table name for game cache
     Value: !Ref GameCacheTable
     Export:
-      Name: !Sub ${EnvironmentName}-bgg-cache-table
+      Name: !Sub ${EnvironmentName}-bgg-game-cache-table
 
   ECSClusterName:
     Description: ECS cluster name

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -34,23 +34,23 @@ Globals:
     Environment:
       Variables:
         CACHE_BACKEND: dynamodb
-        DYNAMODB_TABLE_NAME: !Ref GameCacheTable
+        DYNAMODB_REQUEST_TABLE: !Ref RequestCacheTable
+        DYNAMODB_GAME_TABLE: !Ref GameCacheTable
         AWS_REGION: !Ref AWS::Region
         FLASK_ENV: production
         BGG_TIMEOUT: '60'
         BGG_RETRIES: '6'
         BGG_RETRY_DELAY: '10'
-        ITEM_CACHE_DURATION: '86400'
+        REQUEST_CACHE_DURATION: '86400'
         GAME_CACHE_DURATION: '604800'
-        SQLITE_CACHE_FILE: '/tmp/cache.db'
 
 Resources:
-  # DynamoDB Table for game cache (FREE TIER: 25GB storage, 25 RCU/WCU)
-  GameCacheTable:
+  # DynamoDB Table for request cache (collections, searches) - FREE TIER
+  RequestCacheTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${EnvironmentName}-bgg-game-cache
-      BillingMode: PAY_PER_REQUEST  # Only pay for actual usage, no minimum charges
+      TableName: !Sub ${EnvironmentName}-bgg-request-cache
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
@@ -61,12 +61,41 @@ Resources:
         AttributeName: ttl
         Enabled: true
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: false  # Saves costs, enable for production if needed
+        PointInTimeRecoveryEnabled: false
       Tags:
         - Key: Environment
           Value: !Ref EnvironmentName
         - Key: Application
           Value: bgg-game-selector
+        - Key: CacheType
+          Value: request-cache
+        - Key: CostCenter
+          Value: free-tier
+
+  # DynamoDB Table for game cache (individual game data) - FREE TIER
+  GameCacheTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${EnvironmentName}-bgg-game-cache
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Application
+          Value: bgg-game-selector
+        - Key: CacheType
+          Value: game-cache
         - Key: CostCenter
           Value: free-tier
 
@@ -81,6 +110,8 @@ Resources:
       Architectures:
         - x86_64
       Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RequestCacheTable
         - DynamoDBCrudPolicy:
             TableName: !Ref GameCacheTable
       Events:
@@ -230,11 +261,17 @@ Outputs:
     Export:
       Name: !Sub ${EnvironmentName}-bgg-function-arn
 
-  DynamoDBTableName:
+  DynamoDBRequestTableName:
+    Description: DynamoDB table name for request cache
+    Value: !Ref RequestCacheTable
+    Export:
+      Name: !Sub ${EnvironmentName}-bgg-request-cache-table
+
+  DynamoDBGameTableName:
     Description: DynamoDB table name for game cache
     Value: !Ref GameCacheTable
     Export:
-      Name: !Sub ${EnvironmentName}-bgg-cache-table
+      Name: !Sub ${EnvironmentName}-bgg-game-cache-table
 
   EstimatedMonthlyCost:
     Description: Estimated monthly cost (within free tier limits)

--- a/tests/boardgame/test_request_cache.py
+++ b/tests/boardgame/test_request_cache.py
@@ -1,0 +1,215 @@
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from boardgame.request_cache import (
+    CacheRequestBackendDynamoDB,
+    CacheRequestBackendMemory,
+)
+
+
+class TestCacheRequestBackendMemory(unittest.TestCase):
+    def setUp(self):
+        self.cache = CacheRequestBackendMemory(ttl=2)
+
+    def test_get_nonexistent_key_returns_none(self):
+        result = self.cache.get("nonexistent")
+        assert result is None
+
+    def test_set_and_get_returns_correct_value(self):
+        self.cache.set("key1", "value1")
+        result = self.cache.get("key1")
+        assert result == "value1"
+
+    def test_expired_key_returns_none(self):
+        self.cache.set("key1", "value1")
+        time.sleep(2.1)
+        result = self.cache.get("key1")
+        assert result is None
+
+    def test_delete_removes_key(self):
+        self.cache.set("key1", "value1")
+        self.cache.delete("key1")
+        result = self.cache.get("key1")
+        assert result is None
+
+    def test_clear_removes_all_keys(self):
+        self.cache.set("key1", "value1")
+        self.cache.set("key2", "value2")
+        self.cache.clear()
+        assert self.cache.get("key1") is None
+        assert self.cache.get("key2") is None
+
+    def test_multiple_keys_stored_independently(self):
+        self.cache.set("key1", "value1")
+        self.cache.set("key2", "value2")
+        assert self.cache.get("key1") == "value1"
+        assert self.cache.get("key2") == "value2"
+
+    def test_overwrite_existing_key(self):
+        self.cache.set("key1", "value1")
+        self.cache.set("key1", "value2")
+        result = self.cache.get("key1")
+        assert result == "value2"
+
+    def test_delete_nonexistent_key_no_error(self):
+        self.cache.delete("nonexistent")
+
+    def test_boundary_ttl_zero_seconds(self):
+        cache = CacheRequestBackendMemory(ttl=0)
+        cache.set("key1", "value1")
+        time.sleep(0.1)
+        result = cache.get("key1")
+        assert result is None
+
+    def test_performance_bulk_operations(self):
+        start = time.time()
+        for i in range(1000):
+            self.cache.set(f"key{i}", f"value{i}")
+        set_time = time.time() - start
+
+        start = time.time()
+        for i in range(1000):
+            self.cache.get(f"key{i}")
+        get_time = time.time() - start
+
+        assert set_time < 1.0
+        assert get_time < 1.0
+
+
+@mock_aws
+class TestCacheRequestBackendDynamoDB(unittest.TestCase):
+    def setUp(self):
+        import boto3
+
+        self.dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        self.table = self.dynamodb.create_table(
+            TableName="test-request-cache",
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        self.cache = CacheRequestBackendDynamoDB(
+            table_name="test-request-cache", ttl=1, region="us-east-1"
+        )
+
+    def test_get_nonexistent_key_returns_none(self):
+        result = self.cache.get("nonexistent")
+        assert result is None
+
+    def test_set_and_get_returns_correct_value(self):
+        self.cache.set("key1", "value1")
+        result = self.cache.get("key1")
+        assert result == "value1"
+
+    def test_key_prefixed_with_request(self):
+        self.cache.set("key1", "value1")
+        response = self.table.get_item(Key={"id": "request_key1"})
+        assert "Item" in response
+        assert response["Item"]["data"] == "value1"
+
+    def test_expired_key_returns_none(self):
+        self.cache.set("key1", "value1")
+        time.sleep(1.1)
+        result = self.cache.get("key1")
+        assert result is None
+
+    def test_ttl_attribute_is_set(self):
+        current_time = int(time.time())
+        self.cache.set("key1", "value1")
+        response = self.table.get_item(Key={"id": "request_key1"})
+        ttl = response["Item"]["ttl"]
+        assert ttl > current_time
+        assert ttl <= current_time + 3
+
+    def test_delete_removes_key(self):
+        self.cache.set("key1", "value1")
+        self.cache.delete("key1")
+        result = self.cache.get("key1")
+        assert result is None
+
+    def test_multiple_keys_stored_independently(self):
+        self.cache.set("key1", "value1")
+        self.cache.set("key2", "value2")
+        assert self.cache.get("key1") == "value1"
+        assert self.cache.get("key2") == "value2"
+
+    def test_overwrite_existing_key(self):
+        self.cache.set("key1", "value1")
+        self.cache.set("key1", "value2")
+        result = self.cache.get("key1")
+        assert result == "value2"
+
+    def test_delete_nonexistent_key_no_error(self):
+        self.cache.delete("nonexistent")
+
+    def test_get_handles_client_error_gracefully(self):
+        with patch.object(self.cache.table, "get_item") as mock_get:
+            mock_get.side_effect = ClientError(
+                {"Error": {"Code": "500", "Message": "Internal Server Error"}},
+                "GetItem",
+            )
+            result = self.cache.get("key1")
+            assert result is None
+
+    def test_set_handles_client_error_gracefully(self):
+        with patch.object(self.cache.table, "put_item") as mock_put:
+            mock_put.side_effect = ClientError(
+                {"Error": {"Code": "500", "Message": "Internal Server Error"}},
+                "PutItem",
+            )
+            self.cache.set("key1", "value1")
+
+    def test_delete_handles_client_error_gracefully(self):
+        with patch.object(self.cache.table, "delete_item") as mock_delete:
+            mock_delete.side_effect = ClientError(
+                {"Error": {"Code": "500", "Message": "Internal Server Error"}},
+                "DeleteItem",
+            )
+            self.cache.delete("key1")
+
+    def test_clear_does_nothing(self):
+        self.cache.set("key1", "value1")
+        self.cache.clear()
+        result = self.cache.get("key1")
+        assert result == "value1"
+
+    def test_performance_bulk_operations(self):
+        start = time.time()
+        for i in range(100):
+            self.cache.set(f"key{i}", f"value{i}")
+        set_time = time.time() - start
+
+        start = time.time()
+        for i in range(100):
+            self.cache.get(f"key{i}")
+        get_time = time.time() - start
+
+        assert set_time < 10.0
+        assert get_time < 10.0
+
+    def test_lazy_initialization_of_dynamodb_connection(self):
+        cache = CacheRequestBackendDynamoDB(
+            table_name="test-request-cache", ttl=60, region="us-east-1"
+        )
+        assert cache._dynamodb is None
+        assert cache._table is None
+        cache.set("key1", "value1")
+        assert cache._dynamodb is not None
+        assert cache._table is not None
+
+    def test_large_value_storage(self):
+        large_value = "x" * 10000
+        self.cache.set("large_key", large_value)
+        result = self.cache.get("large_key")
+        assert result == large_value
+
+    def test_special_characters_in_key(self):
+        self.cache.set("key:with:colons", "value1")
+        self.cache.set("key/with/slashes", "value2")
+        assert self.cache.get("key:with:colons") == "value1"
+        assert self.cache.get("key/with/slashes") == "value2"


### PR DESCRIPTION
Replace SQLite-based request cache (not Lambda-friendly) with DynamoDB for production and in-memory cache for local development. Both options stay within AWS free tier limits.

Changes:
- Add CacheRequestBackendDynamoDB for Lambda-compatible caching
- Add CacheRequestBackendMemory for local development
- Split DynamoDB into two tables: request cache + game cache
- Update config to use REQUEST_CACHE_DURATION (renamed from ITEM_CACHE_DURATION)
- Update CloudFormation templates to create both DynamoDB tables
- Update .env.example with new configuration

Architecture:
- Request cache (collections, searches): 1-day TTL
- Game cache (individual games): 7-day TTL
- Separate tables enable independent monitoring and scaling
- Key prefixes prevent collisions: request_ vs game IDs

Free tier compliance:
- Two DynamoDB tables still within 25GB free tier
- Pay-per-request billing = $0 when idle
- Automatic TTL expiration (zero cost)