### PR TITLE
fix: route binary images correctly through API Gateway and fix CORS f…

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import logging
 
 import requests
 import validators
-from flask import Flask, Response, request, jsonify, stream_with_context
+from flask import Flask, Response, request, jsonify
 from flask_cors import CORS
 from werkzeug.routing import BaseConverter
 
@@ -83,9 +83,9 @@ def cors_proxy(url: str):
         decoded_url = base64.urlsafe_b64decode(stripped).decode("utf-8")
         if not validators.url(decoded_url):
             return "Not a valid URL to proxy", 400
-        proxied = requests.get(decoded_url, stream=True, params=request.args)
+        proxied = requests.get(decoded_url, params=request.args)
         response = Response(
-            stream_with_context(proxied.iter_content()),
+            proxied.content,
             content_type=proxied.headers["content-type"],
             status=proxied.status_code,
         )

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -26,11 +26,6 @@ Parameters:
     MinValue: 50
     MaxValue: 5000
 
-  AllowedOrigins:
-    Type: String
-    Default: "https://*.howmanymeeple.com"
-    Description: Allowed CORS origins (comma-separated). Use '*' for development, specific domains for production.
-
   BggAccessToken:
     Type: String
     NoEcho: true
@@ -177,42 +172,84 @@ Resources:
             RestApiId: !Ref ApiGateway
             Path: /health
             Method: GET
+        HealthCheckOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /health
+            Method: OPTIONS
         GetCollection:
           Type: Api
           Properties:
             RestApiId: !Ref ApiGateway
             Path: /collection/{username}
             Method: GET
+        GetCollectionOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /collection/{username}
+            Method: OPTIONS
         GetGeekList:
           Type: Api
           Properties:
             RestApiId: !Ref ApiGateway
             Path: /geeklist/{geek_list}
             Method: GET
+        GetGeekListOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /geeklist/{geek_list}
+            Method: OPTIONS
         SearchGames:
           Type: Api
           Properties:
             RestApiId: !Ref ApiGateway
             Path: /search/{game_name}
             Method: GET
+        SearchGamesOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /search/{game_name}
+            Method: OPTIONS
         CorsProxy:
           Type: Api
           Properties:
             RestApiId: !Ref ApiGateway
             Path: /cors-proxy/{url}
             Method: GET
+        CorsProxyOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /cors-proxy/{url}
+            Method: OPTIONS
         RecommendationsFromGames:
           Type: Api
           Properties:
             RestApiId: !Ref ApiGateway
             Path: /recommendations/from-games
             Method: POST
+        RecommendationsFromGamesOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /recommendations/from-games
+            Method: OPTIONS
         RecommendationsSchema:
           Type: Api
           Properties:
             RestApiId: !Ref ApiGateway
             Path: /recommendations/schema
             Method: GET
+        RecommendationsSchemaOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /recommendations/schema
+            Method: OPTIONS
       Tags:
         Environment: !Ref EnvironmentName
 
@@ -223,10 +260,9 @@ Resources:
       Name: !Sub ${EnvironmentName}-bgg-api
       StageName: !Ref EnvironmentName
       Description: BGG Game Selector API Gateway
-      Cors:
-        AllowOrigin: !Sub "'${AllowedOrigins}'"
-        AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Bgg-Filter-Player-Count,Bgg-Filter-Min-Duration,Bgg-Filter-Max-Duration,Bgg-Filter-Max-Complexity,Bgg-Filter-Min-Rating,Bgg-Filter-Mechanic,Bgg-Filter-Using-Recommended-Players,Bgg-Include-Expansions,Bgg-Field-Whitelist'"
-        AllowMethods: "'GET,POST,OPTIONS'"
+      # CORS is handled by Flask-CORS in the Lambda — OPTIONS requests are routed to Lambda
+      # so it can return the correct Access-Control-Allow-* headers without MOCK integrations,
+      # which break when BinaryMediaTypes includes */* (API Gateway fails to decode MOCK body).
       # Throttling to prevent abuse (FREE TIER PROTECTION)
       MethodSettings:
         - ResourcePath: '/*'
@@ -236,6 +272,8 @@ Resources:
           LoggingLevel: ERROR
           DataTraceEnabled: false
           MetricsEnabled: true
+      BinaryMediaTypes:
+        - '*~1*'
       # API Key requirement (optional, uncomment for additional security)
       # Auth:
       #   ApiKeyRequired: true

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,12 +1,9 @@
-"""
-AWS Lambda handler for BGG Game Selector API.
-
-Wraps the Flask application for serverless deployment.
-"""
-
+import base64
 import json
 import logging
 from typing import Dict, Any
+
+from werkzeug.test import EnvironBuilder
 
 from app import application
 
@@ -50,10 +47,23 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         headers = event.get("headers", {})
         query_params = event.get("queryStringParameters") or {}
 
-        from werkzeug.test import EnvironBuilder
+        raw_body = event.get("body") or ""
+        if event.get("isBase64Encoded"):
+            body = base64.b64decode(raw_body)
+        else:
+            body = raw_body.encode("utf-8") if isinstance(raw_body, str) else raw_body
+
+        content_type = (headers or {}).get(
+            "Content-Type", headers.get("content-type", "")
+        )
 
         builder = EnvironBuilder(
-            method=http_method, path=path, query_string=query_params, headers=headers
+            method=http_method,
+            path=path,
+            query_string=query_params,
+            headers=headers,
+            data=body,
+            content_type=content_type,
         )
         environ = builder.get_environ()
 
@@ -76,15 +86,26 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Extract response details
         status_code = response.status_code
         response_headers = dict(response.headers)
-        response_body = response.get_data(as_text=True)
-
-        # Ensure CORS headers
         response_headers["Access-Control-Allow-Origin"] = "*"
+
+        content_type = response_headers.get("Content-Type", "")
+        is_binary = not (
+            content_type.startswith("text/")
+            or "json" in content_type
+            or "xml" in content_type
+            or "javascript" in content_type
+        )
+
+        if is_binary:
+            body = base64.b64encode(response.get_data()).decode("utf-8")
+        else:
+            body = response.get_data(as_text=True)
 
         return {
             "statusCode": status_code,
             "headers": response_headers,
-            "body": response_body,
+            "body": body,
+            "isBase64Encoded": is_binary,
         }
 
     except Exception as e:


### PR DESCRIPTION
…or production

- cors-proxy: switch from stream_with_context to buffered response (proxied.content) so Lambda can return the full response body before the request context closes
- lambda_handler: handle base64-encoded request bodies from API Gateway; detect binary responses by content-type and return them with isBase64Encoded=true
- serverless-template: add BinaryMediaTypes '*~1*' so API Gateway decodes binary responses when client sends Accept: */*; route OPTIONS to Lambda instead of SAM MOCK integrations (MOCK integrations 500 when BinaryMediaTypes includes */*); remove SAM Cors property as Flask-CORS handles all CORS headers