### PR TITLE
fix: send auth token to geeklist API and surface BGG rate limiting as…

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from boardgame.board_game import (
     BoardGameListNotFoundError,
     BoardGameUserNotFoundError,
 )
+from boardgamegeek.exceptions import BGGApiError
 from boardgame.filter import Filter
 from boardgame.filter_processor import FilterProcessor
 from boardgame.prefetch_status import (
@@ -99,6 +100,8 @@ def show_games_in_collection(username, game_filter):
         return json.dumps(games)
     except BoardGameUserNotFoundError as error:
         return jsonify({"error": error.message}), 404
+    except BGGApiError:
+        return jsonify({"error": "BGG is rate limiting requests, please slow down and retry"}), 503
 
 
 @app.route("/geeklist/<geek_list>")
@@ -114,6 +117,8 @@ def show_games_in_list(geek_list, game_filter):
         return json.dumps(games)
     except (BoardGameUserNotFoundError, BoardGameListNotFoundError) as error:
         return jsonify({"error": error.message}), 404
+    except BGGApiError:
+        return jsonify({"error": "BGG is rate limiting requests, please slow down and retry"}), 503
 
 
 @app.route("/cors-proxy/<b64:url>")

--- a/boardgame/board_game.py
+++ b/boardgame/board_game.py
@@ -67,6 +67,7 @@ class BoardGameFactory(object):
     @staticmethod
     def create_legacy_client():
         return BGGClientLegacy(
+            access_token=Config.BGG_ACCESS_TOKEN,
             cache=BoardGameFactory.create_request_cache(),
             timeout=Config.BGG_TIMEOUT,
             retry_delay=Config.BGG_RETRY_DELAY,

--- a/boardgame/legacy_api.py
+++ b/boardgame/legacy_api.py
@@ -12,12 +12,13 @@ from boardgame.loaders.geeklist import (
 
 log = logging.getLogger("boardgamegeek.legacy_api")
 
-API_ENDPOINT = "http://www.boardgamegeek.com/xmlapi"
+API_ENDPOINT = "https://boardgamegeek.com/xmlapi"
 
 
 class BGGClientLegacy(BGGCommon):
     def __init__(
         self,
+        access_token=None,
         cache=CacheBackendMemory(ttl=3600),
         timeout=15,
         retries=3,
@@ -33,6 +34,7 @@ class BGGClientLegacy(BGGCommon):
             retries=retries,
             retry_delay=retry_delay,
             requests_per_minute=requests_per_minute,
+            access_token=access_token,
         )
         self._search_api_url = None
         self._thing_api_url = None
@@ -60,6 +62,7 @@ class BGGClientLegacy(BGGCommon):
             timeout=self._timeout,
             retries=self._retries,
             retry_delay=self._retry_delay,
+            headers=self._get_auth_headers(),
         )
 
         list = create_geeklist_from_xml(xml_root, listid)

--- a/tests/boardgame/test_prefetch_endpoints.py
+++ b/tests/boardgame/test_prefetch_endpoints.py
@@ -7,6 +7,8 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
+from boardgamegeek.exceptions import BGGApiError
+
 from boardgame.prefetch_status import (
     COMPLETED,
     FAILED,
@@ -263,6 +265,24 @@ class TestCollectionEndpointPrefetchIntegration(unittest.TestCase):
         self._status_store.set(SourceType.GEEKLIST, "99999", FAILED, reason="Timeout")
         response = self._client.get("/geeklist/99999")
         self.assertEqual(response.status_code, 503)
+
+    def test_collection_returns_503_with_rate_limit_message_when_bgg_rate_limits(self):
+        mock_selector = MagicMock()
+        mock_selector.get_games_matching_filter.side_effect = BGGApiError("couldn't fetch data")
+        with patch("app.BoardGameFactory.create_player_selector", return_value=mock_selector):
+            response = self._client.get("/collection/testuser")
+        self.assertEqual(response.status_code, 503)
+        data = json.loads(response.data)
+        self.assertIn("slow down", data["error"])
+
+    def test_geeklist_returns_503_with_rate_limit_message_when_bgg_rate_limits(self):
+        mock_selector = MagicMock()
+        mock_selector.get_games_matching_filter.side_effect = BGGApiError("couldn't fetch data")
+        with patch("app.BoardGameFactory.create_list_selector", return_value=mock_selector):
+            response = self._client.get("/geeklist/99999")
+        self.assertEqual(response.status_code, 503)
+        data = json.loads(response.data)
+        self.assertIn("slow down", data["error"])
 
 
 class TestPrefetchWorker(unittest.TestCase):


### PR DESCRIPTION
… 503

The legacy geeklist endpoint was not sending the BGG access token, causing 401s after BGG added auth to their XML API v1. Three issues fixed:

- Pass BGG_ACCESS_TOKEN through BGGClientLegacy to request headers
- Use boardgamegeek.com (no www) to avoid redirect stripping the auth header
- Catch BGGApiError in collection/geeklist routes and return 503 with a message indicating the caller should slow down and retry