### PR TITLE
docs: add v3 README, deployment docs, and deduplicate codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,246 @@
+# BGG Game Selector API
+
+A REST API for filtering, selecting, and recommending board games from BoardGameGeek (BGG). Caches game data to minimize API calls and runs within AWS free-tier limits.
+
+**v3** is a full rewrite in Scala 3 targeting GraalVM native-image for Lambda deployment. The previous Python implementation is preserved on the [`python-v2`](../../tree/python-v2) branch for reference.
+
+## v3 vs v2
+
+| | v2 (Python) | v3 (Scala) |
+|---|---|---|
+| Runtime | Python 3.11, Flask | Scala 3.3 LTS, Tapir + Ox |
+| Lambda packaging | Docker container (~250 MB) | GraalVM native binary (~30 MB) |
+| Cold start | ~3-5 s | ~200-400 ms |
+| Concurrency model | WSGI (single-threaded per request) | Structured concurrency (Ox) |
+| Recommendations | - | Cosine-similarity vector engine |
+| Type safety | Runtime checks | Compile-time (opaque types, exhaustive matching) |
+| Local dev cache | Memory (lost on restart) | SQLite (persistent) or Memory |
+
+## Prerequisites
+
+**BGG API Access Token**: BoardGameGeek requires authentication for all API endpoints (since December 2024).
+
+1. Register at [BoardGameGeek API Documentation](https://boardgamegeek.com/wiki/page/BGG_XML_API2)
+2. Apply for XML API 2 access and receive your token
+3. Set `BGG_ACCESS_TOKEN=your_token_here` in your environment
+
+**Build tools**: JDK 21+, sbt (installed automatically via `project/build.properties`)
+
+## Quick Start
+
+```bash
+# Local dev with SQLite cache
+export BGG_ACCESS_TOKEN=your_token_here
+export CACHE_BACKEND=sqlite
+make run
+
+# Run tests
+make test
+
+# Format code
+make format
+```
+
+The server starts on `http://localhost:8080`. Use `CACHE_BACKEND=memory` for ephemeral cache (useful for tests).
+
+## Architecture
+
+```
+              POST /prefetch
+Client ──────────────────────────────────────────────────┐
+  │                                                      v
+  │ GET /collection, /geeklist, /recommendations   ┌──────────┐
+  v                                                │ SQS Queue│
+┌─────────────────────────┐                        └─────┬────┘
+│  API Lambda             │                              │
+│  (Tapir + Netty Sync)   │                              v
+│  GraalVM native binary  │                   ┌────────────────────┐
+└───────────┬─────────────┘                   │ Prefetch Worker    │
+            │                                  │ Lambda (15m timeout)│
+            │                                  └──────────┬─────────┘
+            v                                             │
+┌─────────────────────────┐                              │
+│  BGG XML API            │ <────────────────────────────┘
+│  (v1 geeklists, v2 all) │
+└───────────┬─────────────┘
+            │
+            v
+┌───────────────────────────────────────────┐
+│  DynamoDB (prod) / SQLite (local)         │
+│  ├─ Game Cache (7 day TTL)                │
+│  ├─ Vector Store (game embeddings)        │
+│  └─ Prefetch Status (per-status TTLs)     │
+└───────────────────────────────────────────┘
+```
+
+### Caching Strategy
+
+- **Game Cache**: Individual game details cached for 7 days. Fetches from BGG on miss.
+- **Vector Store**: Game feature vectors for the recommendation engine. Updated on cache writes when the game has enough ratings.
+- **Prefetch Status**: Tracks async BGG fetch jobs with per-status TTLs. Avoids the API Gateway 29s timeout on slow BGG responses.
+
+### Recommendation Engine
+
+v3 adds a vector-based recommendation system:
+1. Each game is vectorized across mechanics, categories, and numeric features
+2. User's taste vector is built from their collection
+3. Cosine similarity scores candidate games against the taste vector
+4. Results are filtered using the same header-based filters as collection endpoints
+
+## API Endpoints
+
+### GET /health
+
+Returns service status and cache backend.
+
+### GET /collection/:username
+
+Games from a BGG user's collection, filtered via headers.
+
+### GET /geeklist/:id
+
+Games from a BGG GeekList, filtered via headers.
+
+### GET /search/:query
+
+Search BGG for games by name (minimum 3 characters).
+
+### POST /prefetch
+
+Queue an async BGG fetch. Returns immediately so the frontend doesn't block.
+
+```json
+{"source_type": "collection", "source_id": "username"}
+```
+
+### GET /prefetch/status/:sourceType/:sourceId
+
+Poll prefetch job status: `pending` | `processing` | `completed` | `not_found` | `failed`
+
+### POST /recommendations/from-games
+
+Get game recommendations based on a set of game IDs.
+
+```json
+{"gameIds": [174430, 167791], "limit": 10, "excludeIds": []}
+```
+
+### GET /recommendations/schema
+
+Returns the vector schema (dimensions, mechanic/category vocabulary).
+
+### GET /cors-proxy/:b64url
+
+Proxies an image URL (base64url-encoded) with immutable cache headers. Used by the frontend for BGG thumbnails.
+
+## Filter Headers
+
+All collection/geeklist endpoints accept filtering via HTTP headers:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `Bgg-Filter-Player-Count` | int | Number of players |
+| `Bgg-Filter-Min-Duration` | int | Minimum duration (minutes) |
+| `Bgg-Filter-Max-Duration` | int | Maximum duration (minutes) |
+| `Bgg-Filter-Complexity` | float | Target complexity (1-5); matches within +/-1 |
+| `Bgg-Filter-Min-Rating` | float | Minimum BGG rating |
+| `Bgg-Filter-Mechanic` | string | Required mechanic(s), comma-separated |
+| `Bgg-Filter-Using-Recommended-Players` | bool | Use community player count recommendations (default: true) |
+| `Bgg-Include-Expansions` | bool | Include expansions (default: false) |
+| `Bgg-Field-Whitelist` | string | Comma-separated fields to return |
+
+## Configuration
+
+All config is via environment variables (with defaults in `application.conf`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BGG_ACCESS_TOKEN` | *(required)* | BGG API access token |
+| `CACHE_BACKEND` | `dynamodb` | `dynamodb`, `sqlite`, or `memory` |
+| `BGG_TIMEOUT` | `60` | BGG API timeout (seconds) |
+| `BGG_RETRIES` | `6` | BGG API retry attempts |
+| `BGG_RETRY_DELAY` | `10` | Delay between retries (seconds) |
+| `REQUEST_CACHE_DURATION` | `86400` | Request cache TTL (seconds) |
+| `GAME_CACHE_DURATION` | `604800` | Game cache TTL (seconds) |
+| `VECTOR_MIN_RATINGS` | `100` | Min ratings for vectorization |
+| `AWS_REGION` | `us-east-1` | AWS region |
+| `PREFETCH_SQS_URL` | *(required in prod)* | SQS queue URL (API Lambda sends prefetch jobs here) |
+| `SERVER_HOST` | `0.0.0.0` | Server bind host |
+| `SERVER_PORT` | `8080` | Server bind port |
+
+## Development
+
+```bash
+make compile    # Compile
+make test       # Run all tests
+make format     # scalafmt
+make lint       # Check formatting
+make assembly   # Build fat jar
+make run        # Run locally (fat jar, JVM mode)
+```
+
+### Tech Stack
+
+- **Scala 3.3 LTS** on JDK 21
+- **Tapir** — type-safe endpoint definitions with Netty sync server
+- **Ox** — structured concurrency (direct style, no IO monad)
+- **sttp client4** — synchronous HTTP client for BGG API
+- **Circe** — JSON codec derivation
+- **scala-xml** — BGG XML API parsing
+- **AWS SDK v2** — DynamoDB, SQS (url-connection-client for GraalVM compatibility)
+- **SQLite** — local dev/test cache backend
+- **ScalaTest + ScalaMock** — testing
+
+### Running Tests
+
+```bash
+# All tests
+make test
+
+# Specific suite
+sbt "testOnly bgg.routes.ApiEndpointsSpec"
+
+# With coverage
+sbt coverage test coverageReport
+```
+
+## Deployment
+
+### Building the Native Image
+
+```bash
+make native
+```
+
+This runs the Docker-based GraalVM build (`deployment/Dockerfile.native`) and produces `deployment/bgg-api-native.zip` — a single `bootstrap` binary for Lambda custom runtime (provided.al2023).
+
+### Deploying to AWS
+
+```bash
+sam deploy \
+  --template-file deployment/serverless-template.yaml \
+  --stack-name bgg-game-selector-api \
+  --capabilities CAPABILITY_IAM \
+  --region us-east-1 \
+  --parameter-overrides \
+    EnvironmentName=production \
+    BggAccessToken="your-token-here" \
+  --resolve-s3 \
+  --no-confirm-changeset
+```
+
+The SAM template provisions:
+- API Gateway (rate-limited, CloudWatch logging)
+- API Lambda (native binary, 512 MB, 30s timeout)
+- Prefetch Worker Lambda (native binary, 512 MB, 15m timeout, SQS-triggered)
+- DynamoDB tables (PAY_PER_REQUEST, TTL-enabled)
+- SQS queue + dead-letter queue
+- CloudWatch alarms for free-tier monitoring
+
+### Cost
+
+Designed for AWS free-tier. At typical hobby usage (~1,000 requests/day) the monthly cost is $0. DynamoDB on-demand pricing + automatic TTL means zero cost when idle.
+
+## Previous Versions
+
+The Python v2 codebase is on the [`python-v2`](../../tree/python-v2) branch. It is no longer maintained but serves as reference for the API contract and caching strategy that v3 preserves.

--- a/deployment/DEPLOYMENT.md
+++ b/deployment/DEPLOYMENT.md
@@ -1,0 +1,128 @@
+# Deployment Guide
+
+## Overview
+
+The v3 API deploys as a GraalVM native binary on AWS Lambda (custom runtime `provided.al2023`). This gives ~200-400ms cold starts and runs entirely within AWS free-tier limits.
+
+**Prerequisites:**
+- AWS CLI + SAM CLI configured
+- Docker (for native image build)
+- IAM permissions — see [IAM-SETUP.md](./IAM-SETUP.md)
+- BGG API access token
+
+## Build
+
+```bash
+# From project root — builds the fat jar then native-image via Docker
+make native
+```
+
+This produces `deployment/bgg-api-native.zip` containing a single `bootstrap` binary (~30 MB).
+
+Under the hood:
+1. `sbt assembly` builds the fat jar
+2. Docker runs GraalVM `native-image` against the jar (using `Dockerfile.native`)
+3. The resulting binary is packaged as a Lambda custom runtime zip
+
+## Deploy
+
+```bash
+cd deployment
+
+sam deploy \
+  --template-file serverless-template.yaml \
+  --stack-name bgg-game-selector-api \
+  --capabilities CAPABILITY_IAM \
+  --region us-east-1 \
+  --profile bgg-deployer \
+  --parameter-overrides \
+    EnvironmentName=production \
+    RateLimitPerMinute=100 \
+    BurstLimit=200 \
+    AllowedOrigins="https://*.howmanymeeple.com" \
+    BggAccessToken="your-bgg-api-token" \
+  --resolve-s3 \
+  --no-confirm-changeset
+```
+
+### First Deployment
+
+Use `--guided` for interactive prompts:
+
+```bash
+sam deploy --guided --profile bgg-deployer
+```
+
+### Get API Endpoint
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name bgg-game-selector-api \
+  --query 'Stacks[0].Outputs[?OutputKey==`ApiEndpoint`].OutputValue' \
+  --output text
+```
+
+## What Gets Created
+
+The SAM template provisions:
+
+| Resource | Purpose |
+|----------|---------|
+| API Lambda | Native binary, 512 MB, 30s timeout |
+| Prefetch Worker Lambda | Native binary, 512 MB, 15m timeout, SQS-triggered |
+| API Gateway | REST API with rate limiting and CloudWatch logging |
+| DynamoDB tables (x4) | Request cache, game cache, vectors, prefetch status |
+| SQS queue + DLQ | Async prefetch jobs |
+| CloudWatch alarms | Free-tier usage warnings |
+
+## Cost
+
+| Service | Free Tier | Typical Usage | Monthly Cost |
+|---------|-----------|---------------|--------------|
+| Lambda | 1M requests | ~500K | $0.00 |
+| API Gateway | 1M calls | ~500K | $0.00 |
+| DynamoDB | 25GB, 25 RCU/WCU | ~5GB | $0.00 |
+| SQS | 1M requests | ~10K | $0.00 |
+| **Total** | | | **$0.00** |
+
+## Updating
+
+```bash
+make native
+cd deployment
+sam deploy
+```
+
+## Custom Domain
+
+To map a custom domain:
+
+1. Create ACM certificate in us-east-1
+2. Create API Gateway custom domain mapping
+3. Point Route53 (or DNS) at the API Gateway domain
+
+## Teardown
+
+```bash
+aws cloudformation delete-stack --stack-name bgg-game-selector-api
+```
+
+This deletes all resources including DynamoDB tables — cached data will be lost.
+
+## Troubleshooting
+
+### Lambda Timeout
+
+The API function has a 30s timeout (API Gateway hard limit). Slow BGG fetches should use `POST /prefetch` — the worker Lambda has a 15-minute timeout.
+
+### Cold Start > 1s
+
+Ensure you're deploying the native binary (not the JVM fat jar). Check the CodeUri points to `bgg-api-native.zip`. JVM cold starts are 5-10s; native should be 200-400ms.
+
+### Build Fails on native-image
+
+GraalVM native-image requires reflection configuration for some libraries. If adding new dependencies, you may need to update `META-INF/native-image` configs. Run with `-agentlib:native-image-agent` locally to generate them.
+
+### "Access Denied" on Deploy
+
+Check IAM policy is attached. See [IAM-SETUP.md](./IAM-SETUP.md).

--- a/deployment/IAM-SETUP.md
+++ b/deployment/IAM-SETUP.md
@@ -1,0 +1,64 @@
+# IAM Setup for Deployment
+
+Minimum-privilege IAM user for deploying the BGG Game Selector API via SAM CLI.
+
+## Quick Start
+
+### 1. Create IAM User
+
+1. AWS Console → **IAM** → **Users** → **Create user**
+2. User name: `bgg-api-deployer`
+3. Access type: **Programmatic access**
+
+### 2. Attach Deployment Policy
+
+1. Select **Attach policies directly** → **Create policy**
+2. Switch to **JSON** tab
+3. Paste contents of `deployment/iam-policy.json`
+4. Name: `BGGAPIDeploymentPolicy`
+5. Attach to user
+
+### 3. Configure CLI
+
+```bash
+aws configure --profile bgg-deployer
+# Enter Access Key ID and Secret Access Key
+# Region: us-east-1
+# Output: json
+```
+
+### 4. Verify
+
+```bash
+aws sts get-caller-identity --profile bgg-deployer
+```
+
+## What the Policy Grants
+
+All permissions are scoped to `production-bgg-*` resources:
+
+| Service | Actions | Scope |
+|---------|---------|-------|
+| CloudFormation | Stack operations | `bgg-game-selector*` stacks |
+| Lambda | Function management | `production-bgg-*` functions |
+| API Gateway | REST API management | All REST APIs (can't scope by name) |
+| DynamoDB | Table management + TTL | `production-bgg-*` tables |
+| SQS | Queue management | `production-bgg-*` queues |
+| CloudWatch | Logs + alarms | `production-bgg-*` resources |
+| IAM | Role creation | `production-bgg-*` and SAM roles |
+| S3 | Deployment artifacts | SAM-managed buckets only |
+
+## Changing Environment Prefix
+
+To deploy to `staging` or `dev`, update the `production-bgg-*` patterns in `iam-policy.json` to match your environment name, then set `EnvironmentName` accordingly in your SAM deploy command.
+
+## Cleanup
+
+To remove the deployer user:
+
+1. IAM → Users → `bgg-api-deployer`
+2. Delete access keys
+3. Detach policies
+4. Delete user
+
+Keep the user if you need to update or delete the stack later.

--- a/deployment/iam-policy.json
+++ b/deployment/iam-policy.json
@@ -1,0 +1,114 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormationManagement",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:*"
+      ],
+      "Resource": [
+        "arn:aws:cloudformation:*:*:stack/bgg-game-selector*/*",
+        "arn:aws:cloudformation:*:*:stack/aws-sam-cli-managed-default/*",
+        "arn:aws:cloudformation:*:aws:transform/Serverless-2016-10-31"
+      ]
+    },
+    {
+      "Sid": "S3DeploymentBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*",
+        "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*/*"
+      ]
+    },
+    {
+      "Sid": "LambdaManagement",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:*"
+      ],
+      "Resource": "arn:aws:lambda:*:*:function:production-bgg-*"
+    },
+    {
+      "Sid": "LambdaEventSourceMapping",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:CreateEventSourceMapping",
+        "lambda:DeleteEventSourceMapping",
+        "lambda:GetEventSourceMapping",
+        "lambda:UpdateEventSourceMapping",
+        "lambda:ListEventSourceMappings"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SQSManagement",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:*"
+      ],
+      "Resource": "arn:aws:sqs:*:*:production-bgg-*"
+    },
+    {
+      "Sid": "APIGatewayManagement",
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:*"
+      ],
+      "Resource": [
+        "arn:aws:apigateway:*::/restapis*",
+        "arn:aws:apigateway:*::/tags*",
+        "arn:aws:apigateway:*::/account"
+      ]
+    },
+    {
+      "Sid": "DynamoDBManagement",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:*"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/production-bgg-*"
+    },
+    {
+      "Sid": "CloudWatchManagement",
+      "Effect": "Allow",
+      "Action": [
+        "logs:*",
+        "cloudwatch:*"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:/aws/lambda/production-bgg-*",
+        "arn:aws:cloudwatch:*:*:alarm:production-bgg-*"
+      ]
+    },
+    {
+      "Sid": "IAMRoleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:PassRole",
+        "iam:*RolePolicy",
+        "iam:TagRole",
+        "iam:UntagRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/production-bgg-*",
+        "arn:aws:iam::*:role/bgg-game-selector-api-*",
+        "arn:aws:iam::*:role/aws-sam-cli-managed-default-*"
+      ]
+    },
+    {
+      "Sid": "IAMPolicyReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetPolicy*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/src/main/scala/bgg/SafeOps.scala
+++ b/src/main/scala/bgg/SafeOps.scala
@@ -1,0 +1,32 @@
+package bgg
+
+import com.typesafe.scalalogging.Logger
+import io.circe.{Decoder, parser}
+
+import java.sql.{Connection, PreparedStatement}
+
+object SafeOps:
+  def decodeJson[T: Decoder](json: String, context: String)(using logger: Logger): Option[T] =
+    parser.decode[T](json) match
+      case Right(v) => Some(v)
+      case Left(e) =>
+        logger.error(s"Failed to decode $context", e)
+        None
+
+  def tryAwsCall[T](operation: => T, errorMsg: String)(using logger: Logger): Option[T] =
+    try Some(operation)
+    catch
+      case e: Exception =>
+        logger.error(errorMsg, e)
+        None
+
+  def withStatement[T](conn: Connection, sql: String)(f: PreparedStatement => T): T =
+    val ps = conn.prepareStatement(sql)
+    try f(ps)
+    finally ps.close()
+
+  def trySqlCall(operation: => Unit, errorMsg: String)(using logger: Logger): Unit =
+    try operation
+    catch
+      case e: Exception =>
+        logger.error(errorMsg, e)

--- a/src/main/scala/bgg/bggapi/GameService.scala
+++ b/src/main/scala/bgg/bggapi/GameService.scala
@@ -36,9 +36,8 @@ class GameService(
     bggClient.searchGames(query)
 
   private def partitionCached(ids: List[GameId]): (List[GameData], List[GameId]) =
-    val (hits, misses) = ids.partition(id => gameCache.load(id).isDefined)
-    val hitData = hits.flatMap(gameCache.load)
-    (hitData, misses)
+    val (misses, cached) = ids.partitionMap(id => gameCache.load(id).toRight(id))
+    (cached, misses)
 
   private def cacheAndSync(game: GameData): Unit =
     gameCache.save(game)

--- a/src/main/scala/bgg/cache/DynamoDbGameCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbGameCache.scala
@@ -1,8 +1,8 @@
 package bgg.cache
 
+import bgg.SafeOps.{decodeJson, tryAwsCall}
 import bgg.domain.{GameData, GameId}
-import com.typesafe.scalalogging.StrictLogging
-import io.circe.parser.decode
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
@@ -14,13 +14,14 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String, ttlSeconds: I
     extends GameCache
     with StrictLogging:
 
-  // No-op: DynamoDB TTL handles eviction automatically
+  private given Logger = logger
+
   def evictExpired(): Unit = ()
 
   def save(game: GameData): Unit =
     val ttl = Instant.now().getEpochSecond + ttlSeconds
     val item = Map(
-      "id" -> AttributeValue.fromS(game.id.value.toString),
+      "id" -> AttributeValue.fromS(game.id.asString),
       "data" -> AttributeValue.fromS(game.asJson.noSpaces),
       "cache_timestamp" -> AttributeValue.fromS(Instant.now().toString),
       "ttl" -> AttributeValue.fromN(ttl.toString)
@@ -30,7 +31,6 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String, ttlSeconds: I
       .builder()
       .tableName(tableName)
       .item(item)
-      // Only write if not already cached — avoids redundant writes
       .conditionExpression("attribute_not_exists(id)")
       .build()
 
@@ -47,19 +47,9 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String, ttlSeconds: I
     val request = GetItemRequest
       .builder()
       .tableName(tableName)
-      .key(Map("id" -> AttributeValue.fromS(id.value.toString)).asJava)
+      .key(Map("id" -> AttributeValue.fromS(id.asString)).asJava)
       .build()
 
-    try
-      val response = client.getItem(request)
-      if response.hasItem then
-        decode[GameData](response.item().get("data").s()) match
-          case Right(g) => Some(g)
-          case Left(e) =>
-            logger.error(s"Failed to decode game $id from DynamoDB", e)
-            None
-      else None
-    catch
-      case e: Exception =>
-        logger.error(s"Error loading game $id from DynamoDB", e)
-        None
+    tryAwsCall(client.getItem(request), s"Error loading game $id from DynamoDB")
+      .filter(_.hasItem)
+      .flatMap(response => decodeJson[GameData](response.item().get("data").s(), s"game $id from DynamoDB"))

--- a/src/main/scala/bgg/cache/MemoryGameCache.scala
+++ b/src/main/scala/bgg/cache/MemoryGameCache.scala
@@ -5,19 +5,19 @@ import bgg.domain.{GameData, GameId}
 import java.time.Instant
 import scala.collection.concurrent.TrieMap
 
-// In-memory cache for testing and local development — not thread-safe for TTL, fine for single-request Lambda
 class MemoryGameCache(ttlSeconds: Int) extends GameCache:
-  // TrieMap for lock-free concurrent reads; acceptable for in-memory dev/test use
   private val store: TrieMap[Int, (GameData, Long)] = TrieMap.empty
 
   def save(game: GameData): Unit =
     store.putIfAbsent(game.id.value, (game, Instant.now().getEpochSecond)): Unit
 
   def load(id: GameId): Option[GameData] =
-    store.get(id.value).flatMap { (game, ts) =>
-      if Instant.now().getEpochSecond - ts < ttlSeconds then Some(game)
-      else None
-    }
+    store
+      .updateWith(id.value) {
+        case Some((game, ts)) if Instant.now().getEpochSecond - ts < ttlSeconds => Some((game, ts))
+        case _                                                                  => None
+      }
+      .map(_._1)
 
   def evictExpired(): Unit =
     val cutoff = Instant.now().getEpochSecond - ttlSeconds

--- a/src/main/scala/bgg/cache/SqliteGameCache.scala
+++ b/src/main/scala/bgg/cache/SqliteGameCache.scala
@@ -1,8 +1,8 @@
 package bgg.cache
 
+import bgg.SafeOps.{decodeJson, withStatement}
 import bgg.domain.{GameData, GameId}
-import com.typesafe.scalalogging.StrictLogging
-import io.circe.parser.decode
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
 
 import java.sql.{Connection, DriverManager}
@@ -11,6 +11,8 @@ import java.time.Instant
 class SqliteGameCache(dbPath: String, ttlSeconds: Int) extends GameCache with AutoCloseable with StrictLogging:
   private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
   prepareSchema()
+
+  private given Logger = logger
 
   def close(): Unit = conn.close()
 
@@ -27,37 +29,30 @@ class SqliteGameCache(dbPath: String, ttlSeconds: Int) extends GameCache with Au
   def save(game: GameData): Unit =
     val sql =
       "INSERT INTO cached_game (id, cache_timestamp, data) SELECT ?,?,? WHERE NOT EXISTS(SELECT 1 FROM cached_game WHERE id=?)"
-    val ps = conn.prepareStatement(sql)
-    ps.setString(1, game.id.value.toString)
-    ps.setLong(2, Instant.now().getEpochSecond)
-    ps.setString(3, game.asJson.noSpaces)
-    ps.setString(4, game.id.value.toString)
-    ps.executeUpdate()
-    ps.close()
+    withStatement(conn, sql) { ps =>
+      ps.setString(1, game.id.asString)
+      ps.setLong(2, Instant.now().getEpochSecond)
+      ps.setString(3, game.asJson.noSpaces)
+      ps.setString(4, game.id.asString)
+      ps.executeUpdate()
+    }
     logger.debug(s"Cached game ${game.id.value} (${game.name})")
 
   def load(id: GameId): Option[GameData] =
-    val sql = "SELECT data FROM cached_game WHERE id=?"
-    val ps = conn.prepareStatement(sql)
-    ps.setString(1, id.value.toString)
-    val rs = ps.executeQuery()
-    val result =
-      if rs.next() then
-        decode[GameData](rs.getString(1)) match
-          case Right(g) => Some(g)
-          case Left(e) =>
-            logger.error(s"Failed to decode game $id from cache: $e")
-            None
-      else None
-    rs.close()
-    ps.close()
-    result
+    withStatement(conn, "SELECT data FROM cached_game WHERE id=?") { ps =>
+      ps.setString(1, id.asString)
+      val rs = ps.executeQuery()
+      val result =
+        if rs.next() then decodeJson[GameData](rs.getString(1), s"game $id from cache")
+        else None
+      rs.close()
+      result
+    }
 
   def evictExpired(): Unit =
     val cutoff = Instant.now().getEpochSecond - ttlSeconds
-    val sql = "DELETE FROM cached_game WHERE cache_timestamp < ?"
-    val ps = conn.prepareStatement(sql)
-    ps.setLong(1, cutoff)
-    val deleted = ps.executeUpdate()
-    ps.close()
-    if deleted > 0 then logger.info(s"Evicted $deleted expired games from cache")
+    withStatement(conn, "DELETE FROM cached_game WHERE cache_timestamp < ?") { ps =>
+      ps.setLong(1, cutoff)
+      val deleted = ps.executeUpdate()
+      if deleted > 0 then logger.info(s"Evicted $deleted expired games from cache")
+    }

--- a/src/main/scala/bgg/domain/Model.scala
+++ b/src/main/scala/bgg/domain/Model.scala
@@ -7,7 +7,9 @@ opaque type GameId = Int
 object GameId:
   def apply(value: Int): GameId = value
   def unapply(id: GameId): Some[Int] = Some(id)
-  extension (id: GameId) def value: Int = id
+  extension (id: GameId)
+    def value: Int = id
+    def asString: String = id.toString
   given Codec[GameId] = Codec.from(Decoder.decodeInt.map(GameId(_)), Encoder.encodeInt.contramap(_.value))
 
 opaque type GeekListId = String

--- a/src/main/scala/bgg/lambda/ApiHandler.scala
+++ b/src/main/scala/bgg/lambda/ApiHandler.scala
@@ -32,7 +32,7 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
     val httpBackend = useInScope(DefaultSyncBackend())(_.close())
     val bggClient = BggXmlClient(config.bgg, httpBackend)
 
-    config.cache.backend match
+    val (gameCache, vectorStore, prefetchStore, sqsSender) = config.cache.backend match
       case CacheBackend.DynamoDB =>
         val dynamo = useInScope(
           DynamoDbClient
@@ -48,30 +48,32 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
             .httpClient(UrlConnectionHttpClient.create())
             .build()
         )(_.close())
-
-        val gameCache = DynamoDbGameCache(dynamo, config.aws.dynamoGameTable, config.cache.gameCacheTtlSeconds)
-        val vectorStore = DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable)
-        val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
-        val sqsSender = AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
-        val gameService =
-          GameService(bggClient, gameCache, vectorStore, config.cache.vectorMinRatings, () => Instant.now())
-        ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, sqsSender, config)
+        (
+          DynamoDbGameCache(dynamo, config.aws.dynamoGameTable, config.cache.gameCacheTtlSeconds),
+          DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable),
+          DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable),
+          AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
+        )
 
       case CacheBackend.SQLite =>
-        val gameCache = SqliteGameCache(config.cache.sqliteGameCachePath, config.cache.gameCacheTtlSeconds)
-        val vectorStore = SqliteVectorStore(config.cache.sqliteVectorStorePath)
-        val prefetchStore = SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath)
-        val gameService =
-          GameService(bggClient, gameCache, vectorStore, config.cache.vectorMinRatings, () => Instant.now())
-        ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), config)
+        (
+          SqliteGameCache(config.cache.sqliteGameCachePath, config.cache.gameCacheTtlSeconds),
+          SqliteVectorStore(config.cache.sqliteVectorStorePath),
+          SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
+          NoOpSqsSender()
+        )
 
       case CacheBackend.Memory =>
-        val gameCache = MemoryGameCache(config.cache.gameCacheTtlSeconds)
-        val vectorStore = SqliteVectorStore(config.cache.sqliteVectorStorePath)
-        val prefetchStore = SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath)
-        val gameService =
-          GameService(bggClient, gameCache, vectorStore, config.cache.vectorMinRatings, () => Instant.now())
-        ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), config)
+        (
+          MemoryGameCache(config.cache.gameCacheTtlSeconds),
+          SqliteVectorStore(config.cache.sqliteVectorStorePath),
+          SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
+          NoOpSqsSender()
+        )
+
+    val gameService =
+      GameService(bggClient, gameCache, vectorStore, config.cache.vectorMinRatings, () => Instant.now())
+    ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, sqsSender, config)
 
   private def startServer(endpoints: ApiEndpoints, config: AppConfig): Unit =
     val serverOptions = NettySyncServerOptions.customiseInterceptors

--- a/src/main/scala/bgg/prefetch/DynamoDbPrefetchStatusStore.scala
+++ b/src/main/scala/bgg/prefetch/DynamoDbPrefetchStatusStore.scala
@@ -1,7 +1,8 @@
 package bgg.prefetch
 
+import bgg.SafeOps.tryAwsCall
 import bgg.domain.SourceType
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
 
@@ -12,31 +13,30 @@ class DynamoDbPrefetchStatusStore(client: DynamoDbClient, tableName: String)
     extends PrefetchStatusStore
     with StrictLogging:
 
+  private given Logger = logger
+
   def get(sourceType: SourceType, sourceId: String): Option[PrefetchRecord] =
-    try
-      val response = client.getItem(
+    tryAwsCall(
+      client.getItem(
         GetItemRequest
           .builder()
           .tableName(tableName)
           .key(Map("id" -> AttributeValue.fromS(statusKey(sourceType, sourceId))).asJava)
           .build()
+      ),
+      "Failed to read prefetch status from DynamoDB"
+    ).filter(_.hasItem).flatMap { response =>
+      val item = response.item()
+      val expiresAt = Instant.ofEpochSecond(item.get("ttl").n().toLong)
+      val record = PrefetchRecord(
+        sourceType = SourceType.fromString(item.get("source_type").s()).getOrElse(sourceType),
+        sourceId = item.get("source_id").s(),
+        status = PrefetchStatus.fromDbKey(item.get("status").s()),
+        reason = Option(item.get("reason")).map(_.s()).getOrElse(""),
+        expiresAt = expiresAt
       )
-      if response.hasItem then
-        val item = response.item()
-        val expiresAt = Instant.ofEpochSecond(item.get("ttl").n().toLong)
-        val record = PrefetchRecord(
-          sourceType = SourceType.fromString(item.get("source_type").s()).getOrElse(sourceType),
-          sourceId = item.get("source_id").s(),
-          status = parseStatus(item.get("status").s()),
-          reason = Option(item.get("reason")).map(_.s()).getOrElse(""),
-          expiresAt = expiresAt
-        )
-        Option.when(!record.isExpired)(record)
-      else None
-    catch
-      case e: Exception =>
-        logger.error("Failed to read prefetch status from DynamoDB", e)
-        None
+      Option.when(!record.isExpired)(record)
+    }
 
   def set(sourceType: SourceType, sourceId: String, status: PrefetchStatus, reason: String = ""): Unit =
     val item = Map(
@@ -48,12 +48,7 @@ class DynamoDbPrefetchStatusStore(client: DynamoDbClient, tableName: String)
       "ttl" -> AttributeValue.fromN(PrefetchTtl.expiresAt(status).getEpochSecond.toString)
     ).asJava
 
-    try client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build()): Unit
-    catch case e: Exception => logger.error("Failed to write prefetch status to DynamoDB", e)
-
-  private def parseStatus(s: String): PrefetchStatus = s match
-    case "pending"    => PrefetchStatus.Pending
-    case "processing" => PrefetchStatus.Processing
-    case "completed"  => PrefetchStatus.Completed
-    case "not_found"  => PrefetchStatus.NotFound
-    case _            => PrefetchStatus.Failed
+    tryAwsCall(
+      client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build()),
+      "Failed to write prefetch status to DynamoDB"
+    )

--- a/src/main/scala/bgg/prefetch/PrefetchStatusStore.scala
+++ b/src/main/scala/bgg/prefetch/PrefetchStatusStore.scala
@@ -11,6 +11,14 @@ enum PrefetchStatus(val dbKey: String):
   case NotFound extends PrefetchStatus("not_found")
   case Failed extends PrefetchStatus("failed")
 
+object PrefetchStatus:
+  def fromDbKey(s: String): PrefetchStatus = s match
+    case "pending"    => Pending
+    case "processing" => Processing
+    case "completed"  => Completed
+    case "not_found"  => NotFound
+    case _            => Failed
+
 case class PrefetchRecord(
     sourceType: SourceType,
     sourceId: String,

--- a/src/main/scala/bgg/prefetch/SqlitePrefetchStatusStore.scala
+++ b/src/main/scala/bgg/prefetch/SqlitePrefetchStatusStore.scala
@@ -1,7 +1,8 @@
 package bgg.prefetch
 
+import bgg.SafeOps.{trySqlCall, withStatement}
 import bgg.domain.SourceType
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 
 import java.sql.{Connection, DriverManager}
 import java.time.Instant
@@ -9,6 +10,8 @@ import java.time.Instant
 class SqlitePrefetchStatusStore(dbPath: String) extends PrefetchStatusStore with AutoCloseable with StrictLogging:
   private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
   prepareSchema()
+
+  private given Logger = logger
 
   def close(): Unit = conn.close()
 
@@ -26,45 +29,40 @@ class SqlitePrefetchStatusStore(dbPath: String) extends PrefetchStatusStore with
     stmt.close()
 
   def get(sourceType: SourceType, sourceId: String): Option[PrefetchRecord] =
-    val sql = "SELECT source_type, source_id, status, reason, expires_at FROM prefetch_status WHERE id=?"
-    val ps = conn.prepareStatement(sql)
-    ps.setString(1, statusKey(sourceType, sourceId))
-    val rs = ps.executeQuery()
-    val result =
-      if rs.next() then
-        val expiresAt = Instant.ofEpochSecond(rs.getLong(5))
-        val record = PrefetchRecord(
-          sourceType = SourceType.fromString(rs.getString(1)).getOrElse(sourceType),
-          sourceId = rs.getString(2),
-          status = parseStatus(rs.getString(3)),
-          reason = rs.getString(4),
-          expiresAt = expiresAt
-        )
-        Option.when(!record.isExpired)(record)
-      else None
-    rs.close()
-    ps.close()
-    result
+    withStatement(conn, "SELECT source_type, source_id, status, reason, expires_at FROM prefetch_status WHERE id=?") {
+      ps =>
+        ps.setString(1, statusKey(sourceType, sourceId))
+        val rs = ps.executeQuery()
+        val result =
+          if rs.next() then
+            val expiresAt = Instant.ofEpochSecond(rs.getLong(5))
+            val record = PrefetchRecord(
+              sourceType = SourceType.fromString(rs.getString(1)).getOrElse(sourceType),
+              sourceId = rs.getString(2),
+              status = PrefetchStatus.fromDbKey(rs.getString(3)),
+              reason = rs.getString(4),
+              expiresAt = expiresAt
+            )
+            Option.when(!record.isExpired)(record)
+          else None
+        rs.close()
+        result
+    }
 
   def set(sourceType: SourceType, sourceId: String, status: PrefetchStatus, reason: String = ""): Unit =
     val sql =
       """INSERT INTO prefetch_status (id, source_type, source_id, status, reason, expires_at)
          VALUES (?,?,?,?,?,?)
          ON CONFLICT(id) DO UPDATE SET status=excluded.status, reason=excluded.reason, expires_at=excluded.expires_at"""
-    val ps = conn.prepareStatement(sql)
-    ps.setString(1, statusKey(sourceType, sourceId))
-    ps.setString(2, sourceType.toPathSegment)
-    ps.setString(3, sourceId)
-    ps.setString(4, status.dbKey)
-    ps.setString(5, reason)
-    ps.setLong(6, PrefetchTtl.expiresAt(status).getEpochSecond)
-    try ps.executeUpdate(): Unit
-    catch case e: Exception => logger.error("Failed to write prefetch status", e)
-    finally ps.close()
-
-  private def parseStatus(s: String): PrefetchStatus = s match
-    case "pending"    => PrefetchStatus.Pending
-    case "processing" => PrefetchStatus.Processing
-    case "completed"  => PrefetchStatus.Completed
-    case "not_found"  => PrefetchStatus.NotFound
-    case _            => PrefetchStatus.Failed
+    trySqlCall(
+      withStatement(conn, sql) { ps =>
+        ps.setString(1, statusKey(sourceType, sourceId))
+        ps.setString(2, sourceType.toPathSegment)
+        ps.setString(3, sourceId)
+        ps.setString(4, status.dbKey)
+        ps.setString(5, reason)
+        ps.setLong(6, PrefetchTtl.expiresAt(status).getEpochSecond)
+        ps.executeUpdate()
+      },
+      "Failed to write prefetch status"
+    )

--- a/src/main/scala/bgg/routes/ApiEndpoints.scala
+++ b/src/main/scala/bgg/routes/ApiEndpoints.scala
@@ -78,34 +78,29 @@ class ApiEndpoints(
     }
 
   // GET /collection/:username
-  val collectionEndpoint = baseEndpoint.get
-    .in("collection" / path[String]("username"))
-    .in(headers)
-    .out(jsonBody[List[Json]])
-    .handle { (username, hdrs) =>
-      checkPrefetchBlock(SourceType.Collection, username)
-        .getOrElse {
-          val filters = HeaderFilters.fromHeaders(hdrs)
-          gameService.resolveCollection(username).map { games =>
-            FieldReduction(GameFilter(games, filters), filters.fieldWhitelist)
-          }
-        }
-    }
+  val collectionEndpoint = gameListEndpoint("collection", SourceType.Collection, gameService.resolveCollection)
 
   // GET /geeklist/:id
-  val geeklistEndpoint = baseEndpoint.get
-    .in("geeklist" / path[String]("geekListId"))
-    .in(headers)
-    .out(jsonBody[List[Json]])
-    .handle { (listId, hdrs) =>
-      checkPrefetchBlock(SourceType.GeeKList, listId)
-        .getOrElse {
-          val filters = HeaderFilters.fromHeaders(hdrs)
-          gameService.resolveGeeklist(listId).map { games =>
-            FieldReduction(GameFilter(games, filters), filters.fieldWhitelist)
+  val geeklistEndpoint = gameListEndpoint("geeklist", SourceType.GeeKList, gameService.resolveGeeklist)
+
+  private def gameListEndpoint(
+      segment: String,
+      sourceType: SourceType,
+      resolve: String => Either[Fail, List[GameData]]
+  ) =
+    baseEndpoint.get
+      .in(segment / path[String]("id"))
+      .in(headers)
+      .out(jsonBody[List[Json]])
+      .handle { (id, hdrs) =>
+        checkPrefetchBlock(sourceType, id)
+          .getOrElse {
+            val filters = HeaderFilters.fromHeaders(hdrs)
+            resolve(id).map { games =>
+              FieldReduction(GameFilter(games, filters), filters.fieldWhitelist)
+            }
           }
-        }
-    }
+      }
 
   // GET /search/:query
   val searchEndpoint = baseEndpoint.get

--- a/src/main/scala/bgg/routes/HeaderFilters.scala
+++ b/src/main/scala/bgg/routes/HeaderFilters.scala
@@ -3,28 +3,34 @@ package bgg.routes
 import bgg.domain.GameFilters
 import sttp.model.Header
 
-// Extracts GameFilters from raw request headers (passed as a list from Tapir)
 object HeaderFilters:
 
   def fromHeaders(headers: List[Header]): GameFilters =
-    def get(name: String): Option[String] =
+    val h = Headers(headers)
+    GameFilters(
+      playerCount = h.int("Bgg-Filter-Player-Count"),
+      useRecommendedPlayers = h.bool("Bgg-Filter-Using-Recommended-Players", default = true),
+      minDuration = h.int("Bgg-Filter-Min-Duration"),
+      maxDuration = h.int("Bgg-Filter-Max-Duration"),
+      complexity = h.double("Bgg-Filter-Complexity"),
+      minRating = h.double("Bgg-Filter-Min-Rating"),
+      mechanics = h.list("Bgg-Filter-Mechanic"),
+      includeExpansions = h.bool("Bgg-Include-Expansions", default = false),
+      fieldWhitelist = h.optList("Bgg-Field-Whitelist")
+    )
+
+  private class Headers(headers: List[Header]):
+    private def get(name: String): Option[String] =
       headers.find(_.name.equalsIgnoreCase(name)).map(_.value)
 
-    GameFilters(
-      playerCount = get("Bgg-Filter-Player-Count").flatMap(_.toIntOption),
-      useRecommendedPlayers = get("Bgg-Filter-Using-Recommended-Players")
-        .map(_.toLowerCase != "false")
-        .getOrElse(true),
-      minDuration = get("Bgg-Filter-Min-Duration").flatMap(_.toIntOption),
-      maxDuration = get("Bgg-Filter-Max-Duration").flatMap(_.toIntOption),
-      complexity = get("Bgg-Filter-Complexity").flatMap(_.toDoubleOption),
-      minRating = get("Bgg-Filter-Min-Rating").flatMap(_.toDoubleOption),
-      mechanics = get("Bgg-Filter-Mechanic")
-        .map(_.stripPrefix("[").stripSuffix("]").split(",").map(_.trim).toList)
-        .getOrElse(Nil),
-      includeExpansions = get("Bgg-Include-Expansions")
-        .map(_.toLowerCase == "true")
-        .getOrElse(false),
-      fieldWhitelist = get("Bgg-Field-Whitelist")
-        .map(_.split(",").map(_.trim).toList)
-    )
+    def int(name: String): Option[Int] = get(name).flatMap(_.toIntOption)
+    def double(name: String): Option[Double] = get(name).flatMap(_.toDoubleOption)
+
+    def bool(name: String, default: Boolean): Boolean =
+      get(name).map(v => if default then v.toLowerCase != "false" else v.toLowerCase == "true").getOrElse(default)
+
+    def list(name: String): List[String] =
+      get(name).map(_.stripPrefix("[").stripSuffix("]").split(",").map(_.trim).toList).getOrElse(Nil)
+
+    def optList(name: String): Option[List[String]] =
+      get(name).map(_.split(",").map(_.trim).toList)

--- a/src/main/scala/bgg/store/DynamoDbVectorStore.scala
+++ b/src/main/scala/bgg/store/DynamoDbVectorStore.scala
@@ -1,9 +1,9 @@
 package bgg.store
 
+import bgg.SafeOps.{decodeJson, tryAwsCall}
 import bgg.domain.GameId
 import bgg.vector.GameVector
-import com.typesafe.scalalogging.StrictLogging
-import io.circe.parser.decode
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
@@ -13,41 +13,40 @@ import scala.jdk.CollectionConverters.*
 
 class DynamoDbVectorStore(client: DynamoDbClient, tableName: String) extends VectorStore with StrictLogging:
 
+  private given Logger = logger
+
   def save(sv: StoredVector): Unit =
     val item = Map(
-      "game_id" -> AttributeValue.fromN(sv.gameId.value.toString),
+      "game_id" -> AttributeValue.fromN(sv.gameId.asString),
       "name" -> AttributeValue.fromS(sv.name),
       "vector" -> AttributeValue.fromS(sv.vector.values.asJson.noSpaces),
       "updated_at" -> AttributeValue.fromS(sv.updatedAt.toString)
     ).asJava
 
-    try client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build()): Unit
-    catch case e: Exception => logger.error(s"Error saving vector for game ${sv.gameId.value}", e)
+    tryAwsCall(
+      client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build()),
+      s"Error saving vector for game ${sv.gameId.value}"
+    )
 
   def load(id: GameId): Option[StoredVector] =
-    try
-      val response = client.getItem(
+    tryAwsCall(
+      client.getItem(
         GetItemRequest
           .builder()
           .tableName(tableName)
-          .key(Map("game_id" -> AttributeValue.fromN(id.value.toString)).asJava)
+          .key(Map("game_id" -> AttributeValue.fromN(id.asString)).asJava)
           .build()
-      )
-      if response.hasItem then parseItem(response.item()) else None
-    catch
-      case e: Exception =>
-        logger.error(s"Error loading vector for game $id from DynamoDB", e)
-        None
+      ),
+      s"Error loading vector for game $id from DynamoDB"
+    ).filter(_.hasItem).flatMap(response => parseItem(response.item()))
 
   def loadAll(): List[StoredVector] =
-    try
-      val result = scanAll(exclusiveStartKey = None, acc = Nil)
-      logger.info(s"Loaded ${result.size} vectors from DynamoDB")
-      result
-    catch
-      case e: Exception =>
-        logger.error("Error loading all vectors from DynamoDB", e)
-        Nil
+    tryAwsCall(scanAll(exclusiveStartKey = None, acc = Nil), "Error loading all vectors from DynamoDB")
+      .map { result =>
+        logger.info(s"Loaded ${result.size} vectors from DynamoDB")
+        result
+      }
+      .getOrElse(Nil)
 
   @scala.annotation.tailrec
   private def scanAll(
@@ -63,16 +62,11 @@ class DynamoDbVectorStore(client: DynamoDbClient, tableName: String) extends Vec
     else updated
 
   private def parseItem(item: java.util.Map[String, AttributeValue]): Option[StoredVector] =
-    decode[Vector[Double]](item.get("vector").s()) match
-      case Left(e) =>
-        logger.error(s"Failed to decode vector for item", e)
-        None
-      case Right(vec) =>
-        Some(
-          StoredVector(
-            gameId = GameId(item.get("game_id").n().toInt),
-            name = item.get("name").s(),
-            vector = GameVector(vec),
-            updatedAt = Instant.parse(item.get("updated_at").s())
-          )
-        )
+    decodeJson[Vector[Double]](item.get("vector").s(), "vector from DynamoDB").map { vec =>
+      StoredVector(
+        gameId = GameId(item.get("game_id").n().toInt),
+        name = item.get("name").s(),
+        vector = GameVector(vec),
+        updatedAt = Instant.parse(item.get("updated_at").s())
+      )
+    }

--- a/src/main/scala/bgg/store/SqliteVectorStore.scala
+++ b/src/main/scala/bgg/store/SqliteVectorStore.scala
@@ -1,11 +1,10 @@
 package bgg.store
 
+import bgg.SafeOps.{decodeJson, withStatement}
 import bgg.domain.GameId
 import bgg.vector.GameVector
-import com.typesafe.scalalogging.StrictLogging
-import io.circe.parser.decode
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
-import io.circe.{Decoder, Encoder}
 
 import java.sql.{Connection, DriverManager}
 import java.time.Instant
@@ -13,6 +12,8 @@ import java.time.Instant
 class SqliteVectorStore(dbPath: String) extends VectorStore with AutoCloseable with StrictLogging:
   private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
   prepareSchema()
+
+  private given Logger = logger
 
   def close(): Unit = conn.close()
 
@@ -28,45 +29,38 @@ class SqliteVectorStore(dbPath: String) extends VectorStore with AutoCloseable w
     stmt.close()
 
   def save(sv: StoredVector): Unit =
-    val sql = "INSERT OR REPLACE INTO game_vectors (game_id, name, vector, updated_at) VALUES (?,?,?,?)"
-    val ps = conn.prepareStatement(sql)
-    ps.setInt(1, sv.gameId.value)
-    ps.setString(2, sv.name)
-    ps.setString(3, sv.vector.values.asJson.noSpaces)
-    ps.setString(4, sv.updatedAt.toString)
-    ps.executeUpdate()
-    ps.close()
+    withStatement(conn, "INSERT OR REPLACE INTO game_vectors (game_id, name, vector, updated_at) VALUES (?,?,?,?)") {
+      ps =>
+        ps.setInt(1, sv.gameId.value)
+        ps.setString(2, sv.name)
+        ps.setString(3, sv.vector.values.asJson.noSpaces)
+        ps.setString(4, sv.updatedAt.toString)
+        ps.executeUpdate()
+    }
 
   def load(id: GameId): Option[StoredVector] =
-    val sql = "SELECT game_id, name, vector, updated_at FROM game_vectors WHERE game_id=?"
-    val ps = conn.prepareStatement(sql)
-    ps.setInt(1, id.value)
-    val rs = ps.executeQuery()
-    val result = if rs.next() then rowToStoredVector(rs) else None
-    rs.close()
-    ps.close()
-    result
+    withStatement(conn, "SELECT game_id, name, vector, updated_at FROM game_vectors WHERE game_id=?") { ps =>
+      ps.setInt(1, id.value)
+      val rs = ps.executeQuery()
+      val result = if rs.next() then rowToStoredVector(rs) else None
+      rs.close()
+      result
+    }
 
   def loadAll(): List[StoredVector] =
-    val sql = "SELECT game_id, name, vector, updated_at FROM game_vectors"
-    val ps = conn.prepareStatement(sql)
-    val rs = ps.executeQuery()
-    val results = Iterator.continually(rs).takeWhile(_.next()).flatMap(rowToStoredVector).toList
-    rs.close()
-    ps.close()
-    results
+    withStatement(conn, "SELECT game_id, name, vector, updated_at FROM game_vectors") { ps =>
+      val rs = ps.executeQuery()
+      val results = Iterator.continually(rs).takeWhile(_.next()).flatMap(rowToStoredVector).toList
+      rs.close()
+      results
+    }
 
   private def rowToStoredVector(rs: java.sql.ResultSet): Option[StoredVector] =
-    decode[Vector[Double]](rs.getString(3)) match
-      case Left(e) =>
-        logger.error(s"Failed to decode vector for game ${rs.getInt(1)}", e)
-        None
-      case Right(vec) =>
-        Some(
-          StoredVector(
-            gameId = GameId(rs.getInt(1)),
-            name = rs.getString(2),
-            vector = GameVector(vec),
-            updatedAt = Instant.parse(rs.getString(4))
-          )
-        )
+    decodeJson[Vector[Double]](rs.getString(3), s"vector for game ${rs.getInt(1)}").map { vec =>
+      StoredVector(
+        gameId = GameId(rs.getInt(1)),
+        name = rs.getString(2),
+        vector = GameVector(vec),
+        updatedAt = Instant.parse(rs.getString(4))
+      )
+    }

--- a/src/test/scala/bgg/DynamoDbIntegrationSpec.scala
+++ b/src/test/scala/bgg/DynamoDbIntegrationSpec.scala
@@ -1,0 +1,184 @@
+package bgg
+
+import bgg.cache.DynamoDbGameCache
+import bgg.domain.*
+import bgg.prefetch.{DynamoDbPrefetchStatusStore, PrefetchStatus}
+import bgg.store.{DynamoDbVectorStore, StoredVector}
+import bgg.vector.GameVector
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.*
+
+import java.time.Instant
+import scala.jdk.CollectionConverters.*
+
+class DynamoDbIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll:
+
+  private val localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.5"))
+    .withServices(Service.DYNAMODB)
+
+  private var client: DynamoDbClient = _
+
+  override def beforeAll(): Unit =
+    localstack.start()
+    client = DynamoDbClient
+      .builder()
+      .endpointOverride(localstack.getEndpointOverride(Service.DYNAMODB))
+      .region(Region.of(localstack.getRegion))
+      .credentialsProvider(
+        StaticCredentialsProvider.create(
+          AwsBasicCredentials.create(localstack.getAccessKey, localstack.getSecretKey)
+        )
+      )
+      .build()
+
+    createTable("game-cache", "id", ScalarAttributeType.S)
+    createTable("vectors", "game_id", ScalarAttributeType.N)
+    createTable("prefetch-status", "id", ScalarAttributeType.S)
+
+  override def afterAll(): Unit =
+    if client != null then client.close()
+    localstack.stop()
+
+  private def createTable(name: String, keyName: String, keyType: ScalarAttributeType): Unit =
+    client.createTable(
+      CreateTableRequest
+        .builder()
+        .tableName(name)
+        .keySchema(KeySchemaElement.builder().attributeName(keyName).keyType(KeyType.HASH).build())
+        .attributeDefinitions(
+          AttributeDefinition.builder().attributeName(keyName).attributeType(keyType).build()
+        )
+        .billingMode(BillingMode.PAY_PER_REQUEST)
+        .build()
+    ): Unit
+
+  private val testGame = GameData(
+    id = GameId(174430),
+    name = "Gloomhaven",
+    yearPublished = Some(2017),
+    minPlayers = Some(1),
+    maxPlayers = Some(4),
+    minPlayingTime = Some(60),
+    maxPlayingTime = Some(120),
+    playingTime = Some(120),
+    ratingAverage = Some(8.7),
+    ratingAverageWeight = Some(3.86),
+    expansion = false,
+    mechanics = List("Hand Management", "Campaign"),
+    categories = List("Fantasy", "Adventure"),
+    playerSuggestions = Nil,
+    usersRated = Some(50000)
+  )
+
+  "DynamoDbGameCache" should:
+    "save and load a game" in:
+      val cache = DynamoDbGameCache(client, "game-cache", 3600)
+
+      cache.save(testGame)
+      val loaded = cache.load(GameId(174430))
+
+      loaded shouldBe defined
+      loaded.get.name shouldBe "Gloomhaven"
+      loaded.get.id shouldBe GameId(174430)
+      loaded.get.yearPublished shouldBe Some(2017)
+      loaded.get.mechanics shouldBe List("Hand Management", "Campaign")
+
+    "return None for unknown game" in:
+      val cache = DynamoDbGameCache(client, "game-cache", 3600)
+      cache.load(GameId(999999)) shouldBe None
+
+    "not overwrite existing game (conditional put)" in:
+      val cache = DynamoDbGameCache(client, "game-cache", 3600)
+      val modified = testGame.copy(name = "MODIFIED")
+
+      cache.save(testGame)
+      cache.save(modified)
+
+      val loaded = cache.load(GameId(174430))
+      loaded.get.name shouldBe "Gloomhaven"
+
+  "DynamoDbVectorStore" should:
+    "save and load a vector" in:
+      val store = DynamoDbVectorStore(client, "vectors")
+      val vector = GameVector(Vector.fill(155)(0.5))
+      val now = Instant.parse("2024-01-15T10:30:00Z")
+
+      store.save(StoredVector(GameId(100), "Test Game", vector, now))
+      val loaded = store.load(GameId(100))
+
+      loaded shouldBe defined
+      loaded.get.gameId shouldBe GameId(100)
+      loaded.get.name shouldBe "Test Game"
+      loaded.get.vector.values should have size 155
+      loaded.get.updatedAt shouldBe now
+
+    "return None for unknown game" in:
+      val store = DynamoDbVectorStore(client, "vectors")
+      store.load(GameId(888888)) shouldBe None
+
+    "upsert vector on second save" in:
+      val store = DynamoDbVectorStore(client, "vectors")
+      val v1 = GameVector(Vector.fill(155)(0.1))
+      val v2 = GameVector(Vector.fill(155)(0.9))
+      val now = Instant.now()
+
+      store.save(StoredVector(GameId(200), "Game V1", v1, now))
+      store.save(StoredVector(GameId(200), "Game V2", v2, now))
+
+      val loaded = store.load(GameId(200))
+      loaded.get.name shouldBe "Game V2"
+      loaded.get.vector.values.head shouldBe 0.9
+
+    "loadAll returns all stored vectors" in:
+      val store = DynamoDbVectorStore(client, "vectors")
+      val all = store.loadAll()
+      all.size should be >= 2
+
+  "DynamoDbPrefetchStatusStore" should:
+    "set and get prefetch status" in:
+      val store = DynamoDbPrefetchStatusStore(client, "prefetch-status")
+
+      store.set(SourceType.Collection, "testuser", PrefetchStatus.Pending)
+      val record = store.get(SourceType.Collection, "testuser")
+
+      record shouldBe defined
+      record.get.status shouldBe PrefetchStatus.Pending
+      record.get.sourceId shouldBe "testuser"
+
+    "update status on subsequent set" in:
+      val store = DynamoDbPrefetchStatusStore(client, "prefetch-status")
+
+      store.set(SourceType.Collection, "testuser2", PrefetchStatus.Pending)
+      store.set(SourceType.Collection, "testuser2", PrefetchStatus.Completed)
+
+      val record = store.get(SourceType.Collection, "testuser2")
+      record.get.status shouldBe PrefetchStatus.Completed
+
+    "return None for unknown key" in:
+      val store = DynamoDbPrefetchStatusStore(client, "prefetch-status")
+      store.get(SourceType.Collection, "nobody") shouldBe None
+
+    "store and retrieve reason" in:
+      val store = DynamoDbPrefetchStatusStore(client, "prefetch-status")
+
+      store.set(SourceType.GeeKList, "99999", PrefetchStatus.NotFound, "List not found")
+      val record = store.get(SourceType.GeeKList, "99999")
+
+      record.get.reason shouldBe "List not found"
+
+    "handle different source types independently" in:
+      val store = DynamoDbPrefetchStatusStore(client, "prefetch-status")
+
+      store.set(SourceType.Collection, "user1", PrefetchStatus.Completed)
+      store.set(SourceType.GeeKList, "user1", PrefetchStatus.Failed, "timeout")
+
+      store.get(SourceType.Collection, "user1").get.status shouldBe PrefetchStatus.Completed
+      store.get(SourceType.GeeKList, "user1").get.status shouldBe PrefetchStatus.Failed

--- a/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
+++ b/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
@@ -1,0 +1,331 @@
+package bgg.bggapi
+
+import bgg.config.BggConfig
+import bgg.domain.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import sttp.client4.testing.{ResponseStub, SyncBackendStub}
+import sttp.model.{Header, StatusCode}
+
+class BggXmlClientSpec extends AnyWordSpec with Matchers:
+
+  private val defaultConfig = BggConfig(
+    accessToken = "",
+    timeoutSeconds = 10,
+    retries = 3,
+    retryDelaySeconds = 0
+  )
+
+  private val authenticatedConfig = defaultConfig.copy(accessToken = "test-token-123")
+
+  private def stubBackend(
+      statusCode: StatusCode = StatusCode.Ok,
+      body: String = "<items></items>"
+  ) =
+    SyncBackendStub.whenAnyRequest
+      .thenRespondAdjust(body, statusCode)
+
+  private val collectionXml =
+    """<items totalitems="3">
+      |  <item objecttype="thing" objectid="174430" subtype="boardgame">
+      |    <name sortindex="1">Gloomhaven</name>
+      |  </item>
+      |  <item objecttype="thing" objectid="167791" subtype="boardgame">
+      |    <name sortindex="1">Terraforming Mars</name>
+      |  </item>
+      |  <item objecttype="thing" objectid="169786" subtype="boardgame">
+      |    <name sortindex="1">Scythe</name>
+      |  </item>
+      |</items>""".stripMargin
+
+  private val emptyCollectionXml = """<items totalitems="0"></items>"""
+
+  private val geeklistXml =
+    """<geeklist>
+      |  <item objecttype="thing" objectid="174430" subtype="boardgame">
+      |    <body>Great game</body>
+      |  </item>
+      |  <item objecttype="thing" objectid="167791" subtype="boardgame">
+      |    <body>Also great</body>
+      |  </item>
+      |  <item objecttype="comment" objectid="99999">
+      |    <body>This is a comment, not a game</body>
+      |  </item>
+      |</geeklist>""".stripMargin
+
+  private val emptyGeeklistXml =
+    """<geeklist>
+      |  <item objecttype="comment" objectid="99999">
+      |    <body>Only comments here</body>
+      |  </item>
+      |</geeklist>""".stripMargin
+
+  private val thingXml =
+    """<items>
+      |  <item type="boardgame" id="174430">
+      |    <name type="primary" value="Gloomhaven"/>
+      |    <yearpublished value="2017"/>
+      |    <minplayers value="1"/>
+      |    <maxplayers value="4"/>
+      |    <minplaytime value="60"/>
+      |    <maxplaytime value="120"/>
+      |    <playingtime value="120"/>
+      |    <link type="boardgamemechanic" value="Hand Management"/>
+      |    <link type="boardgamecategory" value="Adventure"/>
+      |    <statistics>
+      |      <ratings>
+      |        <average value="8.7"/>
+      |        <averageweight value="3.86"/>
+      |        <usersrated value="50000"/>
+      |      </ratings>
+      |    </statistics>
+      |  </item>
+      |</items>""".stripMargin
+
+  private val searchXml =
+    """<items total="2">
+      |  <item type="boardgame" id="174430">
+      |    <name type="primary" value="Gloomhaven"/>
+      |  </item>
+      |  <item type="boardgame" id="291457">
+      |    <name type="primary" value="Gloomhaven: Jaws of the Lion"/>
+      |  </item>
+      |</items>""".stripMargin
+
+  "fetchCollection" should:
+    "parse game IDs from collection XML" in:
+      val backend = stubBackend(body = collectionXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("testuser")
+
+      result shouldBe Right(List(GameId(174430), GameId(167791), GameId(169786)))
+
+    "use correct URL with query params" in:
+      var capturedUrl = ""
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedUrl = request.uri.toString
+          ResponseStub.adjust(collectionXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.fetchCollection("myuser")
+
+      capturedUrl should include("xmlapi2/collection")
+      capturedUrl should include("username=myuser")
+      capturedUrl should include("own=1")
+      capturedUrl should include("excludesubtype=boardgameexpansion")
+
+    "return BggUserNotFound when items are empty" in:
+      val backend = stubBackend(body = emptyCollectionXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("unknownuser")
+
+      result shouldBe Left(Fail.BggUserNotFound("unknownuser"))
+
+  "fetchGeeklist" should:
+    "parse game IDs filtering by objecttype=thing" in:
+      val backend = stubBackend(body = geeklistXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchGeeklist("12345")
+
+      result shouldBe Right(List(GameId(174430), GameId(167791)))
+
+    "use URL path based on list ID" in:
+      var capturedUrl = ""
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedUrl = request.uri.toString
+          ResponseStub.adjust(geeklistXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.fetchGeeklist("54321")
+
+      capturedUrl should include("xmlapi/geeklist/54321")
+
+    "return BggListNotFound when no thing items exist" in:
+      val backend = stubBackend(body = emptyGeeklistXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchGeeklist("99999")
+
+      result shouldBe Left(Fail.BggListNotFound("99999"))
+
+  "fetchGamesByIds" should:
+    "parse game data from thing XML" in:
+      val backend = stubBackend(body = thingXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchGamesByIds(List(GameId(174430)))
+
+      result.isRight shouldBe true
+      val games = result.toOption.get
+      games should have size 1
+      games.head.id shouldBe GameId(174430)
+      games.head.name shouldBe "Gloomhaven"
+      games.head.yearPublished shouldBe Some(2017)
+      games.head.minPlayers shouldBe Some(1)
+      games.head.maxPlayers shouldBe Some(4)
+      games.head.minPlayingTime shouldBe Some(60)
+      games.head.maxPlayingTime shouldBe Some(120)
+      games.head.ratingAverage shouldBe Some(8.7)
+      games.head.ratingAverageWeight shouldBe Some(3.86)
+      games.head.mechanics shouldBe List("Hand Management")
+      games.head.categories shouldBe List("Adventure")
+
+    "batch IDs into groups of 20" in:
+      var requestCount = 0
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { _ =>
+          requestCount += 1
+          ResponseStub.adjust(thingXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val ids = (1 to 45).map(GameId(_)).toList
+      client.fetchGamesByIds(ids)
+
+      requestCount shouldBe 3
+
+    "join IDs with commas in the request" in:
+      var capturedUrl = ""
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedUrl = request.uri.toString
+          ResponseStub.adjust(thingXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.fetchGamesByIds(List(GameId(100), GameId(200), GameId(300)))
+
+      capturedUrl should include("xmlapi2/thing")
+      capturedUrl should include("id=100,200,300")
+      capturedUrl should include("stats=1")
+
+    "return empty list on failure for a batch" in:
+      val backend = stubBackend(statusCode = StatusCode.TooManyRequests)
+      val client = BggXmlClient(defaultConfig.copy(retries = 1), backend)
+
+      val result = client.fetchGamesByIds(List(GameId(1)))
+
+      result shouldBe Right(Nil)
+
+  "searchGames" should:
+    "return empty list for queries shorter than 3 characters" in:
+      val backend = stubBackend()
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.searchGames("ab") shouldBe Right(Nil)
+      client.searchGames("a") shouldBe Right(Nil)
+      client.searchGames("") shouldBe Right(Nil)
+
+    "search with correct URL params" in:
+      var capturedUrl = ""
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedUrl = request.uri.toString
+          ResponseStub.adjust("<items></items>", StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.searchGames("gloomhaven")
+
+      capturedUrl should include("xmlapi2/search")
+      capturedUrl should include("query=gloomhaven")
+      capturedUrl should include("type=boardgame")
+
+    "limit results to 20 games" in:
+      val manyResultsXml =
+        "<items>" +
+          (1 to 25)
+            .map(i => s"""<item type="boardgame" id="$i"><name type="primary" value="Game $i"/></item>""")
+            .mkString +
+          "</items>"
+      var fetchCount = 0
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          val url = request.uri.toString
+          if url.contains("search") then ResponseStub.adjust(manyResultsXml, StatusCode.Ok)
+          else
+            fetchCount += 1
+            ResponseStub.adjust(thingXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.searchGames("game")
+
+      fetchCount shouldBe 20
+
+  "retry logic" should:
+    "retry on 202 responses" in:
+      var requestCount = 0
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { _ =>
+          requestCount += 1
+          if requestCount < 3 then ResponseStub.adjust("", StatusCode.Accepted)
+          else ResponseStub.adjust(collectionXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("testuser")
+
+      result.isRight shouldBe true
+      requestCount shouldBe 3
+
+    "return BggRateLimited after exhausting retries on 202" in:
+      val backend = stubBackend(statusCode = StatusCode.Accepted, body = "")
+      val client = BggXmlClient(defaultConfig.copy(retries = 2), backend)
+
+      val result = client.fetchCollection("testuser")
+
+      result shouldBe a[Left[?, ?]]
+      result.left.toOption.get shouldBe a[Fail.BggRateLimited]
+
+    "return BggRateLimited on 429 response" in:
+      val backend = stubBackend(statusCode = StatusCode.TooManyRequests, body = "")
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("testuser")
+
+      result shouldBe a[Left[?, ?]]
+      result.left.toOption.get shouldBe a[Fail.BggRateLimited]
+
+    "return IncorrectInput on unexpected status codes" in:
+      val backend = stubBackend(statusCode = StatusCode.InternalServerError, body = "")
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("testuser")
+
+      result shouldBe a[Left[?, ?]]
+      result.left.toOption.get shouldBe a[Fail.IncorrectInput]
+
+  "auth headers" should:
+    "send Bearer token when accessToken is non-empty" in:
+      var capturedHeaders: Map[String, String] = Map.empty
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedHeaders = request.headers.map(h => h.name -> h.value).toMap
+          ResponseStub.adjust(collectionXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(authenticatedConfig, backend)
+
+      client.fetchCollection("testuser")
+
+      capturedHeaders should contain("Authorization" -> "Bearer test-token-123")
+
+    "not send Authorization header when accessToken is empty" in:
+      var capturedHeaders: Map[String, String] = Map.empty
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedHeaders = request.headers.map(h => h.name -> h.value).toMap
+          ResponseStub.adjust(collectionXml, StatusCode.Ok)
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.fetchCollection("testuser")
+
+      capturedHeaders should not contain key("Authorization")

--- a/src/test/scala/bgg/bggapi/XmlParserSpec.scala
+++ b/src/test/scala/bgg/bggapi/XmlParserSpec.scala
@@ -1,0 +1,370 @@
+package bgg.bggapi
+
+import bgg.domain.{GameData, GameId, PlayerSuggestion}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class XmlParserSpec extends AnyWordSpec with Matchers:
+
+  "parseThings" should:
+    "parse a single complete item" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="174430">
+            <name type="primary" value="Gloomhaven"/>
+            <name type="alternate" value="Some Alternate Name"/>
+            <yearpublished value="2017"/>
+            <minplayers value="1"/>
+            <maxplayers value="4"/>
+            <minplaytime value="60"/>
+            <maxplaytime value="120"/>
+            <playingtime value="120"/>
+            <link type="boardgamemechanic" value="Hand Management"/>
+            <link type="boardgamemechanic" value="Campaign"/>
+            <link type="boardgamecategory" value="Fantasy"/>
+            <link type="boardgamecategory" value="Adventure"/>
+            <poll name="suggested_numplayers">
+              <results numplayers="2">
+                <result value="Best" numvotes="50"/>
+                <result value="Recommended" numvotes="30"/>
+                <result value="Not Recommended" numvotes="5"/>
+              </results>
+              <results numplayers="3">
+                <result value="Best" numvotes="80"/>
+                <result value="Recommended" numvotes="20"/>
+                <result value="Not Recommended" numvotes="2"/>
+              </results>
+            </poll>
+            <statistics>
+              <ratings>
+                <average value="8.7"/>
+                <averageweight value="3.86"/>
+                <usersrated value="50000"/>
+              </ratings>
+            </statistics>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result should have size 1
+
+      val game = result.head
+      game.id shouldBe GameId(174430)
+      game.name shouldBe "Gloomhaven"
+      game.yearPublished shouldBe Some(2017)
+      game.minPlayers shouldBe Some(1)
+      game.maxPlayers shouldBe Some(4)
+      game.minPlayingTime shouldBe Some(60)
+      game.maxPlayingTime shouldBe Some(120)
+      game.playingTime shouldBe Some(120)
+      game.ratingAverage shouldBe Some(8.7)
+      game.ratingAverageWeight shouldBe Some(3.86)
+      game.usersRated shouldBe Some(50000)
+      game.expansion shouldBe false
+      game.mechanics shouldBe List("Hand Management", "Campaign")
+      game.categories shouldBe List("Fantasy", "Adventure")
+      game.playerSuggestions shouldBe List(
+        PlayerSuggestion(numericPlayerCount = 2, best = 50, recommended = 30, notRecommended = 5),
+        PlayerSuggestion(numericPlayerCount = 3, best = 80, recommended = 20, notRecommended = 2)
+      )
+
+    "parse multiple items" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="1">
+            <name type="primary" value="Game One"/>
+            <yearpublished value="2000"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+          <item type="boardgame" id="2">
+            <name type="primary" value="Game Two"/>
+            <yearpublished value="2010"/>
+            <minplayers value="3"/>
+            <maxplayers value="6"/>
+            <minplaytime value="60"/>
+            <maxplaytime value="90"/>
+            <playingtime value="75"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result should have size 2
+      result.map(_.name) shouldBe List("Game One", "Game Two")
+      result.map(_.id) shouldBe List(GameId(1), GameId(2))
+
+    "return empty list when no items present" in:
+      val xml = <items></items>
+      XmlParser.parseThings(xml) shouldBe empty
+
+    "identify expansions by type attribute" in:
+      val xml =
+        <items>
+          <item type="boardgameexpansion" id="99">
+            <name type="primary" value="Some Expansion"/>
+            <yearpublished value="2021"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result should have size 1
+      result.head.expansion shouldBe true
+
+    "use primary name and ignore alternates" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="5">
+            <name type="alternate" value="Alt Name"/>
+            <name type="primary" value="Primary Name"/>
+            <name type="alternate" value="Another Alt"/>
+            <yearpublished value="2015"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.name shouldBe "Primary Name"
+
+    "default name to empty string when no primary name exists" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="7">
+            <name type="alternate" value="Only Alternate"/>
+            <yearpublished value="2015"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.name shouldBe ""
+
+    "handle missing optional numeric attributes" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="10">
+            <name type="primary" value="Minimal Game"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result should have size 1
+
+      val game = result.head
+      game.yearPublished shouldBe None
+      game.minPlayers shouldBe None
+      game.maxPlayers shouldBe None
+      game.minPlayingTime shouldBe None
+      game.maxPlayingTime shouldBe None
+      game.playingTime shouldBe None
+      game.ratingAverage shouldBe None
+      game.ratingAverageWeight shouldBe None
+      game.usersRated shouldBe None
+      game.mechanics shouldBe empty
+      game.categories shouldBe empty
+      game.playerSuggestions shouldBe empty
+
+    "handle non-numeric values in numeric attributes gracefully" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="11">
+            <name type="primary" value="Bad Data Game"/>
+            <yearpublished value="unknown"/>
+            <minplayers value="abc"/>
+            <maxplayers value=""/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+            <statistics>
+              <ratings>
+                <average value="N/A"/>
+                <averageweight value=""/>
+                <usersrated value="xyz"/>
+              </ratings>
+            </statistics>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result should have size 1
+
+      val game = result.head
+      game.yearPublished shouldBe None
+      game.minPlayers shouldBe None
+      game.maxPlayers shouldBe None
+      game.minPlayingTime shouldBe Some(30)
+      game.maxPlayingTime shouldBe Some(60)
+      game.ratingAverage shouldBe None
+      game.ratingAverageWeight shouldBe None
+      game.usersRated shouldBe None
+
+    "skip items without an id attribute" in:
+      val xml =
+        <items>
+          <item type="boardgame">
+            <name type="primary" value="No Id Game"/>
+            <yearpublished value="2020"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+          <item type="boardgame" id="42">
+            <name type="primary" value="Has Id"/>
+            <yearpublished value="2020"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result should have size 1
+      result.head.name shouldBe "Has Id"
+
+    "filter link types correctly for mechanics and categories" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="20">
+            <name type="primary" value="Link Test"/>
+            <link type="boardgamemechanic" value="Worker Placement"/>
+            <link type="boardgamecategory" value="Strategy"/>
+            <link type="boardgamedesigner" value="Some Designer"/>
+            <link type="boardgamefamily" value="Some Family"/>
+            <link type="boardgamemechanic" value="Dice Rolling"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.mechanics shouldBe List("Worker Placement", "Dice Rolling")
+      result.head.categories shouldBe List("Strategy")
+
+    "skip non-numeric player count ranges in suggestions" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="30">
+            <name type="primary" value="Poll Test"/>
+            <poll name="suggested_numplayers">
+              <results numplayers="2">
+                <result value="Best" numvotes="10"/>
+                <result value="Recommended" numvotes="5"/>
+                <result value="Not Recommended" numvotes="1"/>
+              </results>
+              <results numplayers="4+">
+                <result value="Best" numvotes="3"/>
+                <result value="Recommended" numvotes="7"/>
+                <result value="Not Recommended" numvotes="20"/>
+              </results>
+            </poll>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.playerSuggestions should have size 1
+      result.head.playerSuggestions.head.numericPlayerCount shouldBe 2
+
+    "handle missing vote values in suggestions" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="31">
+            <name type="primary" value="Missing Votes"/>
+            <poll name="suggested_numplayers">
+              <results numplayers="3">
+                <result value="Best" numvotes="10"/>
+              </results>
+            </poll>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      val suggestion = result.head.playerSuggestions.head
+      suggestion.numericPlayerCount shouldBe 3
+      suggestion.best shouldBe 10
+      suggestion.recommended shouldBe 0
+      suggestion.notRecommended shouldBe 0
+
+    "handle non-numeric numvotes gracefully" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="32">
+            <name type="primary" value="Bad Votes"/>
+            <poll name="suggested_numplayers">
+              <results numplayers="2">
+                <result value="Best" numvotes="abc"/>
+                <result value="Recommended" numvotes="5"/>
+                <result value="Not Recommended" numvotes=""/>
+              </results>
+            </poll>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      val suggestion = result.head.playerSuggestions.head
+      suggestion.best shouldBe 0
+      suggestion.recommended shouldBe 5
+      suggestion.notRecommended shouldBe 0
+
+    "ignore polls with names other than suggested_numplayers" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="33">
+            <name type="primary" value="Other Poll"/>
+            <poll name="language_dependence">
+              <results numplayers="1">
+                <result value="Best" numvotes="99"/>
+              </results>
+            </poll>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.playerSuggestions shouldBe empty
+
+    "handle item with no poll element" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="34">
+            <name type="primary" value="No Poll"/>
+            <yearpublished value="2019"/>
+            <minplayers value="2"/>
+            <maxplayers value="4"/>
+            <minplaytime value="30"/>
+            <maxplaytime value="60"/>
+            <playingtime value="45"/>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.playerSuggestions shouldBe empty
+
+    "handle statistics without ratings node" in:
+      val xml =
+        <items>
+          <item type="boardgame" id="35">
+            <name type="primary" value="Empty Stats"/>
+            <statistics></statistics>
+          </item>
+        </items>
+
+      val result = XmlParser.parseThings(xml)
+      result.head.ratingAverage shouldBe None
+      result.head.ratingAverageWeight shouldBe None
+      result.head.usersRated shouldBe None

--- a/src/test/scala/bgg/config/AppConfigSpec.scala
+++ b/src/test/scala/bgg/config/AppConfigSpec.scala
@@ -1,0 +1,126 @@
+package bgg.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AppConfigSpec extends AnyWordSpec with Matchers:
+
+  "AppConfig.load()" should:
+    "read all fields from typesafe config" in:
+      System.setProperty("bgg.accessToken", "test-token-123")
+      System.setProperty("bgg.timeoutSeconds", "30")
+      System.setProperty("bgg.retries", "5")
+      System.setProperty("bgg.retryDelaySeconds", "2")
+      System.setProperty("cache.backend", "sqlite")
+      System.setProperty("cache.requestCacheTtlSeconds", "1000")
+      System.setProperty("cache.gameCacheTtlSeconds", "2000")
+      System.setProperty("cache.vectorMinRatings", "75")
+      System.setProperty("cache.sqliteRequestCachePath", "/tmp/req.sqlite")
+      System.setProperty("cache.sqliteGameCachePath", "/tmp/game.sqlite")
+      System.setProperty("cache.sqliteVectorStorePath", "/tmp/vec.sqlite")
+      System.setProperty("cache.sqlitePrefetchStatusPath", "/tmp/pf.sqlite")
+      System.setProperty("aws.region", "eu-west-1")
+      System.setProperty("aws.dynamoRequestTable", "req-table")
+      System.setProperty("aws.dynamoGameTable", "game-table")
+      System.setProperty("aws.dynamoVectorTable", "vec-table")
+      System.setProperty("aws.dynamoPrefetchTable", "pf-table")
+      System.setProperty("aws.prefetchSqsUrl", "https://sqs.example.com/queue")
+      System.setProperty("server.host", "127.0.0.1")
+      System.setProperty("server.port", "9090")
+
+      ConfigFactory.invalidateCaches()
+
+      try
+        val config = AppConfig.load()
+
+        config.bgg.accessToken shouldBe "test-token-123"
+        config.bgg.timeoutSeconds shouldBe 30
+        config.bgg.retries shouldBe 5
+        config.bgg.retryDelaySeconds shouldBe 2
+
+        config.cache.backend shouldBe CacheBackend.SQLite
+        config.cache.requestCacheTtlSeconds shouldBe 1000
+        config.cache.gameCacheTtlSeconds shouldBe 2000
+        config.cache.vectorMinRatings shouldBe 75
+        config.cache.sqliteRequestCachePath shouldBe "/tmp/req.sqlite"
+        config.cache.sqliteGameCachePath shouldBe "/tmp/game.sqlite"
+        config.cache.sqliteVectorStorePath shouldBe "/tmp/vec.sqlite"
+        config.cache.sqlitePrefetchStatusPath shouldBe "/tmp/pf.sqlite"
+
+        config.aws.region shouldBe "eu-west-1"
+        config.aws.dynamoRequestTable shouldBe "req-table"
+        config.aws.dynamoGameTable shouldBe "game-table"
+        config.aws.dynamoVectorTable shouldBe "vec-table"
+        config.aws.dynamoPrefetchTable shouldBe "pf-table"
+        config.aws.prefetchSqsUrl shouldBe "https://sqs.example.com/queue"
+
+        config.server.host shouldBe "127.0.0.1"
+        config.server.port shouldBe 9090
+      finally
+        System.clearProperty("bgg.accessToken")
+        System.clearProperty("bgg.timeoutSeconds")
+        System.clearProperty("bgg.retries")
+        System.clearProperty("bgg.retryDelaySeconds")
+        System.clearProperty("cache.backend")
+        System.clearProperty("cache.requestCacheTtlSeconds")
+        System.clearProperty("cache.gameCacheTtlSeconds")
+        System.clearProperty("cache.vectorMinRatings")
+        System.clearProperty("cache.sqliteRequestCachePath")
+        System.clearProperty("cache.sqliteGameCachePath")
+        System.clearProperty("cache.sqliteVectorStorePath")
+        System.clearProperty("cache.sqlitePrefetchStatusPath")
+        System.clearProperty("aws.region")
+        System.clearProperty("aws.dynamoRequestTable")
+        System.clearProperty("aws.dynamoGameTable")
+        System.clearProperty("aws.dynamoVectorTable")
+        System.clearProperty("aws.dynamoPrefetchTable")
+        System.clearProperty("aws.prefetchSqsUrl")
+        System.clearProperty("server.host")
+        System.clearProperty("server.port")
+        ConfigFactory.invalidateCaches()
+
+    "map 'dynamodb' backend string to CacheBackend.DynamoDB" in:
+      System.setProperty("cache.backend", "dynamodb")
+      ConfigFactory.invalidateCaches()
+      try
+        val config = AppConfig.load()
+        config.cache.backend shouldBe CacheBackend.DynamoDB
+      finally
+        System.clearProperty("cache.backend")
+        ConfigFactory.invalidateCaches()
+
+    "map 'memory' backend string to CacheBackend.Memory" in:
+      System.setProperty("cache.backend", "memory")
+      ConfigFactory.invalidateCaches()
+      try
+        val config = AppConfig.load()
+        config.cache.backend shouldBe CacheBackend.Memory
+      finally
+        System.clearProperty("cache.backend")
+        ConfigFactory.invalidateCaches()
+
+    "map unknown backend string to CacheBackend.Memory" in:
+      System.setProperty("cache.backend", "redis")
+      ConfigFactory.invalidateCaches()
+      try
+        val config = AppConfig.load()
+        config.cache.backend shouldBe CacheBackend.Memory
+      finally
+        System.clearProperty("cache.backend")
+        ConfigFactory.invalidateCaches()
+
+    "use defaults from application.conf when no overrides set" in:
+      ConfigFactory.invalidateCaches()
+      val config = AppConfig.load()
+
+      config.bgg.timeoutSeconds shouldBe 60
+      config.bgg.retries shouldBe 6
+      config.bgg.retryDelaySeconds shouldBe 10
+      config.cache.requestCacheTtlSeconds shouldBe 86400
+      config.cache.gameCacheTtlSeconds shouldBe 604800
+      config.cache.vectorMinRatings shouldBe 100
+      config.aws.region shouldBe "us-east-1"
+      config.server.host shouldBe "0.0.0.0"
+      config.server.port shouldBe 8080
+      config.server.allowedOrigins shouldBe List("*")

--- a/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
@@ -1,0 +1,157 @@
+package bgg.lambda
+
+import bgg.bggapi.{BggClient, GameService}
+import bgg.cache.MemoryGameCache
+import bgg.domain.*
+import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
+import bgg.store.SqliteVectorStore
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Files, Paths}
+import java.time.Instant
+
+class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
+
+  private val prefetchDb = "test_worker_prefetch.sqlite"
+  private val vectorDb = "test_worker_vectors.sqlite"
+  private var prefetchStore: SqlitePrefetchStatusStore = _
+  private var vectorStore: SqliteVectorStore = _
+  private var gameCache: MemoryGameCache = _
+
+  override def beforeEach(): Unit =
+    Files.deleteIfExists(Paths.get(prefetchDb)): Unit
+    Files.deleteIfExists(Paths.get(vectorDb)): Unit
+    prefetchStore = SqlitePrefetchStatusStore(prefetchDb)
+    vectorStore = SqliteVectorStore(vectorDb)
+    gameCache = MemoryGameCache(ttlSeconds = 3600)
+
+  override def afterEach(): Unit =
+    prefetchStore.close()
+    vectorStore.close()
+    Files.deleteIfExists(Paths.get(prefetchDb)): Unit
+    Files.deleteIfExists(Paths.get(vectorDb)): Unit
+
+  private def testGame(id: Int, name: String): GameData = GameData(
+    id = GameId(id),
+    name = name,
+    yearPublished = Some(2020),
+    minPlayers = Some(2),
+    maxPlayers = Some(4),
+    minPlayingTime = Some(30),
+    maxPlayingTime = Some(60),
+    playingTime = Some(60),
+    ratingAverage = Some(7.5),
+    ratingAverageWeight = Some(2.5),
+    expansion = false,
+    mechanics = List("Hand Management"),
+    categories = List("Fantasy"),
+    playerSuggestions = Nil,
+    usersRated = Some(500)
+  )
+
+  private def stubClient(
+      collectionResult: Either[Fail, List[GameId]] = Right(Nil),
+      geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
+      gamesResult: Either[Fail, List[GameData]] = Right(Nil)
+  ): BggClient = new BggClient:
+    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
+    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
+    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
+    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+
+  private def makeLogic(client: BggClient): PrefetchWorkerLogic =
+    val gameService = GameService(client, gameCache, vectorStore, 50, () => Instant.now())
+    PrefetchWorkerLogic(gameService, prefetchStore)
+
+  "PrefetchWorkerLogic" should:
+
+    "set status to Completed on successful collection prefetch" in:
+      val games = List(testGame(1, "Catan"), testGame(2, "Pandemic"))
+      val client = stubClient(
+        collectionResult = Right(List(GameId(1), GameId(2))),
+        gamesResult = Right(games)
+      )
+      val logic = makeLogic(client)
+
+      logic.process(PrefetchMessage("collection", "testuser"))
+
+      val record = prefetchStore.get(SourceType.Collection, "testuser")
+      record.map(_.status) shouldBe Some(PrefetchStatus.Completed)
+
+    "set status to Completed on successful geeklist prefetch" in:
+      val games = List(testGame(10, "Chess"))
+      val client = stubClient(
+        geeklistResult = Right(List(GameId(10))),
+        gamesResult = Right(games)
+      )
+      val logic = makeLogic(client)
+
+      logic.process(PrefetchMessage("geeklist", "12345"))
+
+      val record = prefetchStore.get(SourceType.GeeKList, "12345")
+      record.map(_.status) shouldBe Some(PrefetchStatus.Completed)
+
+    "set status to NotFound when collection user doesn't exist" in:
+      val client = stubClient(collectionResult = Left(Fail.BggUserNotFound("ghost")))
+      val logic = makeLogic(client)
+
+      logic.process(PrefetchMessage("collection", "ghost"))
+
+      val record = prefetchStore.get(SourceType.Collection, "ghost")
+      record.map(_.status) shouldBe Some(PrefetchStatus.NotFound)
+      record.map(_.reason).get should include("ghost")
+
+    "set status to NotFound when geeklist doesn't exist" in:
+      val client = stubClient(geeklistResult = Left(Fail.BggListNotFound("99999")))
+      val logic = makeLogic(client)
+
+      logic.process(PrefetchMessage("geeklist", "99999"))
+
+      val record = prefetchStore.get(SourceType.GeeKList, "99999")
+      record.map(_.status) shouldBe Some(PrefetchStatus.NotFound)
+      record.map(_.reason).get should include("99999")
+
+    "set status to Failed on BGG rate limit" in:
+      val client = stubClient(collectionResult = Left(Fail.BggRateLimited("Too many")))
+      val logic = makeLogic(client)
+
+      logic.process(PrefetchMessage("collection", "testuser"))
+
+      val record = prefetchStore.get(SourceType.Collection, "testuser")
+      record.map(_.status) shouldBe Some(PrefetchStatus.Failed)
+      record.map(_.reason).get should include("BggRateLimited")
+
+    "set status to Processing before completion" in:
+      var statusDuringFetch: Option[PrefetchStatus] = None
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] =
+          statusDuringFetch = prefetchStore.get(SourceType.Collection, username).map(_.status)
+          Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+
+      val logic = makeLogic(client)
+      logic.process(PrefetchMessage("collection", "testuser"))
+
+      statusDuringFetch shouldBe Some(PrefetchStatus.Processing)
+
+    "handle invalid source_type gracefully without crashing" in:
+      val client = stubClient()
+      val logic = makeLogic(client)
+
+      noException should be thrownBy logic.process(PrefetchMessage("invalid_type", "testuser"))
+
+    "cache fetched games during prefetch" in:
+      val games = List(testGame(1, "Catan"))
+      val client = stubClient(
+        collectionResult = Right(List(GameId(1))),
+        gamesResult = Right(games)
+      )
+      val logic = makeLogic(client)
+
+      logic.process(PrefetchMessage("collection", "testuser"))
+
+      gameCache.load(GameId(1)).map(_.name) shouldBe Some("Catan")

--- a/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
+++ b/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
@@ -13,11 +13,13 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import sttp.client4.*
-import sttp.client4.testing.BackendStub
-import sttp.model.StatusCode
+import sttp.client4.testing.{BackendStub, ResponseStub, SyncBackendStub}
+import sttp.model.{Header as SttpHeader, StatusCode}
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 import sttp.tapir.server.stub4.TapirStubInterpreter
+
+import java.util.Base64
 
 import java.nio.file.{Files, Paths}
 import java.time.Instant
@@ -418,3 +420,151 @@ class ApiEndpointsSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach
       response.code shouldBe StatusCode.Ok
       val json = parseJson(response.body).getOrElse(Json.Null)
       json.hcursor.get[Int]("total_dimensions").toOption shouldBe Some(155)
+
+  "GET /cors-proxy/:b64url" should:
+    def encodeUrl(url: String): String =
+      "_" + Base64.getUrlEncoder.withoutPadding.encodeToString(url.getBytes("UTF-8"))
+
+    def makeProxyEndpoints(httpStub: SyncBackendStub): ApiEndpoints =
+      val client = stubClient()
+      val gameService = GameService(client, gameCache, vectorStore, 50, () => Instant.now())
+      ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig, httpStub)
+
+    "proxy a valid base64url-encoded https URL" in:
+      val targetUrl = "https://example.com/image.png"
+      val responseBody = Array[Byte](1, 2, 3, 4, 5)
+      val httpStub = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          if request.uri.toString == targetUrl then
+            ResponseStub.adjust(responseBody, StatusCode.Ok, Seq(SttpHeader("content-type", "image/png")))
+          else ResponseStub.adjust(Array.empty[Byte], StatusCode.NotFound)
+        }
+
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val encoded = encodeUrl(targetUrl)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/$encoded")
+        .response(asByteArrayAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      response.body shouldBe responseBody
+      response.header("Content-Type") shouldBe Some("image/png")
+      response.header("Cache-Control") shouldBe Some("public, max-age=31536000, immutable")
+
+    "proxy a valid base64url-encoded http URL" in:
+      val targetUrl = "http://example.com/data.json"
+      val responseBody = """{"key":"value"}""".getBytes("UTF-8")
+      val httpStub = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          if request.uri.toString == targetUrl then
+            ResponseStub.adjust(responseBody, StatusCode.Ok, Seq(SttpHeader("content-type", "application/json")))
+          else ResponseStub.adjust(Array.empty[Byte], StatusCode.NotFound)
+        }
+
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val encoded = encodeUrl(targetUrl)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/$encoded")
+        .response(asByteArrayAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      response.body shouldBe responseBody
+      response.header("Content-Type") shouldBe Some("application/json")
+
+    "return 400 for invalid base64 input" in:
+      val httpStub = SyncBackendStub
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/_!!!not-valid-base64!!!")
+        .response(asStringAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.BadRequest
+      val json = parseJson(response.body).getOrElse(Json.Null)
+      json.hcursor.get[String]("error").toOption.get should include("Unable to decode")
+
+    "return 400 when decoded string is not a URL" in:
+      val notAUrl = "not-a-url"
+      val encoded = "_" + Base64.getUrlEncoder.withoutPadding.encodeToString(notAUrl.getBytes("UTF-8"))
+      val httpStub = SyncBackendStub
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/$encoded")
+        .response(asStringAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.BadRequest
+      val json = parseJson(response.body).getOrElse(Json.Null)
+      json.hcursor.get[String]("error").toOption.get should include("Not a valid URL")
+
+    "handle URL that requires base64url padding correctly" in:
+      val targetUrl = "https://x.co/a"
+      val responseBody = Array[Byte](10, 20, 30)
+      val httpStub = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          if request.uri.toString == targetUrl then
+            ResponseStub.adjust(
+              responseBody,
+              StatusCode.Ok,
+              Seq(SttpHeader("content-type", "application/octet-stream"))
+            )
+          else ResponseStub.adjust(Array.empty[Byte], StatusCode.NotFound)
+        }
+
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val encoded = encodeUrl(targetUrl)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/$encoded")
+        .response(asByteArrayAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      response.body shouldBe responseBody
+
+    "handle URL with characters that differ between base64 and base64url" in:
+      val targetUrl = "https://example.com/path?foo=bar&baz=qux+quux"
+      val responseBody = Array[Byte](99)
+      val httpStub = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          if request.uri.toString == targetUrl then
+            ResponseStub.adjust(responseBody, StatusCode.Ok, Seq(SttpHeader("content-type", "text/plain")))
+          else ResponseStub.adjust(Array.empty[Byte], StatusCode.NotFound)
+        }
+
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val encoded = encodeUrl(targetUrl)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/$encoded")
+        .response(asByteArrayAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      response.body shouldBe responseBody
+
+    "use application/octet-stream when upstream has no content-type" in:
+      val targetUrl = "https://example.com/no-content-type"
+      val responseBody = Array[Byte](0, 1)
+      val httpStub = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          if request.uri.toString == targetUrl then ResponseStub.adjust(responseBody, StatusCode.Ok)
+          else ResponseStub.adjust(Array.empty[Byte], StatusCode.NotFound)
+        }
+
+      val endpoints = makeProxyEndpoints(httpStub)
+      val backend = makeBackend(endpoints)
+      val encoded = encodeUrl(targetUrl)
+      val response = basicRequest
+        .get(uri"http://test/cors-proxy/$encoded")
+        .response(asByteArrayAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      response.header("Content-Type") shouldBe Some("application/octet-stream")

--- a/src/test/scala/bgg/routes/FieldReductionSpec.scala
+++ b/src/test/scala/bgg/routes/FieldReductionSpec.scala
@@ -1,0 +1,112 @@
+package bgg.routes
+
+import bgg.domain.*
+import io.circe.Json
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FieldReductionSpec extends AnyWordSpec with Matchers:
+
+  private def game(id: Int, name: String): GameData = GameData(
+    id = GameId(id),
+    name = name,
+    yearPublished = Some(2020),
+    minPlayers = Some(2),
+    maxPlayers = Some(4),
+    minPlayingTime = Some(30),
+    maxPlayingTime = Some(60),
+    playingTime = Some(60),
+    ratingAverage = Some(7.5),
+    ratingAverageWeight = Some(2.5),
+    expansion = false,
+    mechanics = List("Hand Management"),
+    categories = List("Fantasy"),
+    playerSuggestions = Nil,
+    usersRated = Some(500)
+  )
+
+  "FieldReduction" should:
+
+    "return all fields when whitelist is None" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, None)
+
+      result should have size 1
+      val json = result.head
+      json.hcursor.get[String]("name").toOption shouldBe Some("Catan")
+      json.hcursor.get[Int]("id").toOption shouldBe Some(1)
+      json.hcursor.get[Int]("yearPublished").toOption shouldBe Some(2020)
+      json.hcursor.get[Int]("minPlayers").toOption shouldBe Some(2)
+
+    "filter to only specified fields" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, Some(List("name", "id")))
+
+      result should have size 1
+      val json = result.head
+      json.hcursor.get[String]("name").toOption shouldBe Some("Catan")
+      json.hcursor.get[Int]("id").toOption shouldBe Some(1)
+      json.hcursor.get[Int]("yearPublished").toOption shouldBe None
+      json.hcursor.get[Int]("minPlayers").toOption shouldBe None
+
+    "return empty JSON objects when whitelist is empty" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, Some(Nil))
+
+      result should have size 1
+      val json = result.head
+      json.asObject.get.size shouldBe 0
+
+    "ignore fields that do not exist in the JSON" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, Some(List("name", "nonExistentField", "alsoMissing")))
+
+      result should have size 1
+      val json = result.head
+      json.asObject.get.size shouldBe 1
+      json.hcursor.get[String]("name").toOption shouldBe Some("Catan")
+
+    "apply field reduction to multiple games" in:
+      val games = List(game(1, "Catan"), game(2, "Pandemic"))
+      val result = FieldReduction(games, Some(List("name", "id")))
+
+      result should have size 2
+      result(0).hcursor.get[String]("name").toOption shouldBe Some("Catan")
+      result(0).hcursor.get[Int]("id").toOption shouldBe Some(1)
+      result(1).hcursor.get[String]("name").toOption shouldBe Some("Pandemic")
+      result(1).hcursor.get[Int]("id").toOption shouldBe Some(2)
+
+    "return an empty list when given no games" in:
+      val result = FieldReduction(Nil, Some(List("name")))
+      result shouldBe empty
+
+    "return an empty list when given no games and no whitelist" in:
+      val result = FieldReduction(Nil, None)
+      result shouldBe empty
+
+    "preserve nested structures in whitelisted fields" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, Some(List("mechanics")))
+
+      result should have size 1
+      val json = result.head
+      val mechanics = json.hcursor.get[List[String]]("mechanics").toOption
+      mechanics shouldBe Some(List("Hand Management"))
+
+    "preserve boolean fields correctly" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, Some(List("expansion")))
+
+      result should have size 1
+      val json = result.head
+      json.hcursor.get[Boolean]("expansion").toOption shouldBe Some(false)
+
+    "only include fields present in both whitelist and JSON" in:
+      val games = List(game(1, "Catan"))
+      val result = FieldReduction(games, Some(List("name", "foo", "mechanics", "bar")))
+
+      result should have size 1
+      val json = result.head
+      json.asObject.get.size shouldBe 2
+      json.hcursor.get[String]("name").toOption shouldBe Some("Catan")
+      json.hcursor.get[List[String]]("mechanics").toOption shouldBe Some(List("Hand Management"))

--- a/src/test/scala/bgg/routes/HeaderFiltersSpec.scala
+++ b/src/test/scala/bgg/routes/HeaderFiltersSpec.scala
@@ -1,0 +1,160 @@
+package bgg.routes
+
+import bgg.domain.GameFilters
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import sttp.model.Header
+
+class HeaderFiltersSpec extends AnyWordSpec with Matchers:
+
+  private def headers(pairs: (String, String)*): List[Header] =
+    pairs.map((name, value) => Header(name, value)).toList
+
+  "HeaderFilters.fromHeaders" should:
+
+    "return default filters when no headers are present" in:
+      val filters = HeaderFilters.fromHeaders(Nil)
+      filters.playerCount shouldBe None
+      filters.useRecommendedPlayers shouldBe true
+      filters.minDuration shouldBe None
+      filters.maxDuration shouldBe None
+      filters.complexity shouldBe None
+      filters.minRating shouldBe None
+      filters.mechanics shouldBe Nil
+      filters.includeExpansions shouldBe false
+      filters.fieldWhitelist shouldBe None
+
+    "parse Bgg-Filter-Player-Count header" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Player-Count" -> "4"))
+      filters.playerCount shouldBe Some(4)
+
+    "return None for invalid Bgg-Filter-Player-Count" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Player-Count" -> "abc"))
+      filters.playerCount shouldBe None
+
+    "return None for empty Bgg-Filter-Player-Count" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Player-Count" -> ""))
+      filters.playerCount shouldBe None
+
+    "parse Bgg-Filter-Using-Recommended-Players as true by default" in:
+      val filters = HeaderFilters.fromHeaders(Nil)
+      filters.useRecommendedPlayers shouldBe true
+
+    "parse Bgg-Filter-Using-Recommended-Players when explicitly true" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Using-Recommended-Players" -> "true"))
+      filters.useRecommendedPlayers shouldBe true
+
+    "parse Bgg-Filter-Using-Recommended-Players when false" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Using-Recommended-Players" -> "false"))
+      filters.useRecommendedPlayers shouldBe false
+
+    "parse Bgg-Filter-Using-Recommended-Players case-insensitively" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Using-Recommended-Players" -> "FALSE"))
+      filters.useRecommendedPlayers shouldBe false
+
+    "treat non-false values for Bgg-Filter-Using-Recommended-Players as true" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Using-Recommended-Players" -> "yes"))
+      filters.useRecommendedPlayers shouldBe true
+
+    "parse Bgg-Filter-Min-Duration header" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Min-Duration" -> "30"))
+      filters.minDuration shouldBe Some(30)
+
+    "return None for invalid Bgg-Filter-Min-Duration" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Min-Duration" -> "not-a-number"))
+      filters.minDuration shouldBe None
+
+    "parse Bgg-Filter-Max-Duration header" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Max-Duration" -> "120"))
+      filters.maxDuration shouldBe Some(120)
+
+    "return None for invalid Bgg-Filter-Max-Duration" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Max-Duration" -> "3.5"))
+      filters.maxDuration shouldBe None
+
+    "parse Bgg-Filter-Complexity header" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Complexity" -> "2.5"))
+      filters.complexity shouldBe Some(2.5)
+
+    "return None for invalid Bgg-Filter-Complexity" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Complexity" -> "medium"))
+      filters.complexity shouldBe None
+
+    "parse Bgg-Filter-Min-Rating header" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Min-Rating" -> "7.5"))
+      filters.minRating shouldBe Some(7.5)
+
+    "return None for invalid Bgg-Filter-Min-Rating" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Min-Rating" -> "high"))
+      filters.minRating shouldBe None
+
+    "parse Bgg-Filter-Mechanic header with single mechanic" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Mechanic" -> "Worker Placement"))
+      filters.mechanics shouldBe List("Worker Placement")
+
+    "parse Bgg-Filter-Mechanic header with multiple comma-separated mechanics" in:
+      val filters =
+        HeaderFilters.fromHeaders(headers("Bgg-Filter-Mechanic" -> "Worker Placement, Dice Rolling, Hand Management"))
+      filters.mechanics shouldBe List("Worker Placement", "Dice Rolling", "Hand Management")
+
+    "parse Bgg-Filter-Mechanic header with bracket-wrapped list" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Filter-Mechanic" -> "[Worker Placement, Dice Rolling]"))
+      filters.mechanics shouldBe List("Worker Placement", "Dice Rolling")
+
+    "return empty list when Bgg-Filter-Mechanic is absent" in:
+      val filters = HeaderFilters.fromHeaders(Nil)
+      filters.mechanics shouldBe Nil
+
+    "parse Bgg-Include-Expansions as true" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Include-Expansions" -> "true"))
+      filters.includeExpansions shouldBe true
+
+    "parse Bgg-Include-Expansions as false when absent" in:
+      val filters = HeaderFilters.fromHeaders(Nil)
+      filters.includeExpansions shouldBe false
+
+    "parse Bgg-Include-Expansions case-insensitively" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Include-Expansions" -> "TRUE"))
+      filters.includeExpansions shouldBe true
+
+    "treat non-true values for Bgg-Include-Expansions as false" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Include-Expansions" -> "yes"))
+      filters.includeExpansions shouldBe false
+
+    "parse Bgg-Field-Whitelist header" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Field-Whitelist" -> "name, id, mechanics"))
+      filters.fieldWhitelist shouldBe Some(List("name", "id", "mechanics"))
+
+    "return None for fieldWhitelist when header is absent" in:
+      val filters = HeaderFilters.fromHeaders(Nil)
+      filters.fieldWhitelist shouldBe None
+
+    "parse Bgg-Field-Whitelist with single field" in:
+      val filters = HeaderFilters.fromHeaders(headers("Bgg-Field-Whitelist" -> "name"))
+      filters.fieldWhitelist shouldBe Some(List("name"))
+
+    "handle case-insensitive header name lookup" in:
+      val filters = HeaderFilters.fromHeaders(headers("bgg-filter-player-count" -> "3"))
+      filters.playerCount shouldBe Some(3)
+
+    "parse multiple headers simultaneously" in:
+      val filters = HeaderFilters.fromHeaders(
+        headers(
+          "Bgg-Filter-Player-Count" -> "4",
+          "Bgg-Filter-Min-Duration" -> "30",
+          "Bgg-Filter-Max-Duration" -> "120",
+          "Bgg-Filter-Complexity" -> "3.0",
+          "Bgg-Filter-Min-Rating" -> "7.0",
+          "Bgg-Filter-Mechanic" -> "Worker Placement, Dice Rolling",
+          "Bgg-Include-Expansions" -> "true",
+          "Bgg-Field-Whitelist" -> "name, id"
+        )
+      )
+      filters.playerCount shouldBe Some(4)
+      filters.minDuration shouldBe Some(30)
+      filters.maxDuration shouldBe Some(120)
+      filters.complexity shouldBe Some(3.0)
+      filters.minRating shouldBe Some(7.0)
+      filters.mechanics shouldBe List("Worker Placement", "Dice Rolling")
+      filters.includeExpansions shouldBe true
+      filters.fieldWhitelist shouldBe Some(List("name", "id"))


### PR DESCRIPTION
Restore documentation lost during the Python→Scala rewrite:
- README.md covering v3 platform, v2 comparison, API reference
- deployment/DEPLOYMENT.md and IAM-SETUP.md updated for native Lambda
- deployment/iam-policy.json restored from python-v2 branch

Refactor repeated patterns into shared utilities:
- SafeOps: decodeJson, tryAwsCall, trySqlCall, withStatement
- PrefetchStatus.fromDbKey replaces duplicated parseStatus methods
- GameId.asString extension removes .value.toString chains
- ApiEndpoints: parameterized gameListEndpoint for collection/geeklist
- HeaderFilters: typed header extraction via private Headers class
- ApiHandler: extract common GameService wiring from match arms
- GameService: single-pass partitionCached via partitionMap
- MemoryGameCache: thread-safe via atomic updateWith