### PR TITLE
feat: add CloudFront CDN for image caching, refactor data layer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val scala3Version = "3.3.8"
 
 ThisBuild / organization := "bgg"
 ThisBuild / scalaVersion := scala3Version
-ThisBuild / version      := "3.1.0"
+ThisBuild / version      := "3.3.0"
 
 ThisBuild / scalacOptions ++= Seq(
   "-Wunused:all",

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: 'BGG Game Selector API v3.2.0 - Scala/Tapir native Lambda'
+Description: 'BGG Game Selector API v3.3.0 - Scala/Tapir native Lambda'
 
 Parameters:
   EnvironmentName:
@@ -48,7 +48,7 @@ Globals:
         DYNAMODB_PREFETCH_TABLE: !Ref PrefetchStatusTable
         DYNAMODB_REGION: !Ref AWS::Region
         BGG_ACCESS_TOKEN: !Ref BggAccessToken
-        BGG_TIMEOUT: '60'
+        BGG_TIMEOUT: '240'
         BGG_RETRIES: '6'
         BGG_RETRY_DELAY: '10'
         REQUEST_CACHE_DURATION: '86400'
@@ -300,6 +300,12 @@ Resources:
           Properties:
             Queue: !GetAtt PrefetchQueue.Arn
             BatchSize: 1
+        WeeklyHotListWarm:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 4 ? * MON *)
+            Description: Warm the hot games cache every Monday at 4am UTC
+            Input: '{"Records":[{"body":"{\"source_type\":\"hot\",\"source_id\":\"trending\"}"}]}'
       Tags:
         Environment: !Ref EnvironmentName
 
@@ -323,6 +329,53 @@ Resources:
       Tags:
         Environment: !Ref EnvironmentName
         CostCenter: free-tier
+
+  # CloudFront CDN — caches /cors-proxy/* at edge to avoid hot-linking BGG images
+  CdnDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: !Sub ${EnvironmentName} BGG API CDN — image caching
+        HttpVersion: http2and3
+        PriceClass: PriceClass_100
+        Origins:
+          - Id: ApiGatewayOrigin
+            DomainName: !Sub ${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com
+            OriginPath: !Sub /${EnvironmentName}
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+        DefaultCacheBehavior:
+          TargetOriginId: ApiGatewayOrigin
+          ViewerProtocolPolicy: https-only
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+          OriginRequestPolicyId: b689b0a0-8776-4f12-925b-acf3a0e33d7c
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - PATCH
+            - POST
+            - DELETE
+          Compress: true
+        CacheBehaviors:
+          - PathPattern: /cors-proxy/*
+            TargetOriginId: ApiGatewayOrigin
+            ViewerProtocolPolicy: https-only
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+            AllowedMethods:
+              - GET
+              - HEAD
+            Compress: true
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Application
+          Value: bgg-game-selector
 
   # CloudWatch Log Groups
   ApiLogGroup:
@@ -368,8 +421,14 @@ Resources:
       TreatMissingData: notBreaching
 
 Outputs:
+  CdnEndpoint:
+    Description: CloudFront CDN URL (use this for frontend — caches cors-proxy images at edge)
+    Value: !Sub https://${CdnDistribution.DomainName}
+    Export:
+      Name: !Sub ${EnvironmentName}-bgg-cdn-url
+
   ApiEndpoint:
-    Description: API Gateway endpoint URL
+    Description: API Gateway endpoint URL (direct, bypasses CDN)
     Value: !Sub https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}
     Export:
       Name: !Sub ${EnvironmentName}-bgg-api-url

--- a/src/main/scala/bgg/SafeOps.scala
+++ b/src/main/scala/bgg/SafeOps.scala
@@ -3,7 +3,7 @@ package bgg
 import com.typesafe.scalalogging.Logger
 import io.circe.{Decoder, parser}
 
-import java.sql.{Connection, PreparedStatement}
+import java.sql.{Connection, PreparedStatement, ResultSet}
 
 object SafeOps:
   def decodeJson[T: Decoder](json: String, context: String)(using logger: Logger): Option[T] =
@@ -20,13 +20,16 @@ object SafeOps:
         logger.error(errorMsg, e)
         None
 
-  def withStatement[T](conn: Connection, sql: String)(f: PreparedStatement => T): T =
-    val ps = conn.prepareStatement(sql)
-    try f(ps)
-    finally ps.close()
-
   def trySqlCall(operation: => Unit, errorMsg: String)(using logger: Logger): Unit =
     try operation
     catch
       case e: Exception =>
         logger.error(errorMsg, e)
+
+  def withStatement[T](conn: Connection, sql: String)(f: PreparedStatement => T): T =
+    val ps = conn.prepareStatement(sql)
+    try f(ps)
+    finally ps.close()
+
+  def resultSetIterator(rs: ResultSet): Iterator[ResultSet] =
+    Iterator.continually(rs).takeWhile(_.next())

--- a/src/main/scala/bgg/SqliteStore.scala
+++ b/src/main/scala/bgg/SqliteStore.scala
@@ -1,0 +1,16 @@
+package bgg
+
+import com.typesafe.scalalogging.{Logger, StrictLogging}
+
+import java.sql.{Connection, DriverManager}
+
+trait SqliteStore(dbPath: String, schema: String) extends AutoCloseable with StrictLogging:
+  protected val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
+  protected given Logger = logger
+
+  locally:
+    val stmt = conn.createStatement()
+    try stmt.execute(schema): Unit
+    finally stmt.close()
+
+  def close(): Unit = conn.close()

--- a/src/main/scala/bgg/cache/DynamoDbGameCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbGameCache.scala
@@ -10,21 +10,19 @@ import software.amazon.awssdk.services.dynamodb.model.*
 import java.time.Instant
 import scala.jdk.CollectionConverters.*
 
-class DynamoDbGameCache(client: DynamoDbClient, tableName: String, ttlSeconds: Int)
-    extends GameCache
-    with StrictLogging:
+class DynamoDbGameCache(client: DynamoDbClient, tableName: String) extends GameCache with StrictLogging:
 
   private given Logger = logger
 
   def evictExpired(): Unit = ()
 
-  def save(game: GameData): Unit =
-    val ttl = Instant.now().getEpochSecond + ttlSeconds
+  def save(game: GameData, now: Instant): Unit =
+    val ttl = AdaptiveTtl.computeTtl(game.yearPublished, now)
     val item = Map(
       "id" -> AttributeValue.fromS(game.id.asString),
       "data" -> AttributeValue.fromS(game.asJson.noSpaces),
-      "cache_timestamp" -> AttributeValue.fromS(Instant.now().toString),
-      "ttl" -> AttributeValue.fromN(ttl.toString)
+      "cache_timestamp" -> AttributeValue.fromS(now.toString),
+      "ttl" -> AttributeValue.fromN((now.getEpochSecond + ttl.getSeconds).toString)
     ).asJava
 
     val request = PutItemRequest
@@ -36,7 +34,7 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String, ttlSeconds: I
 
     try
       client.putItem(request)
-      logger.debug(s"Cached game ${game.id.value} (${game.name})")
+      logger.debug(s"Cached game ${game.id.value} (${game.name}) with adaptive TTL ${ttl.toDays}d")
     catch
       case _: ConditionalCheckFailedException =>
         logger.debug(s"Game ${game.id.value} already cached")

--- a/src/main/scala/bgg/cache/MemoryGameCache.scala
+++ b/src/main/scala/bgg/cache/MemoryGameCache.scala
@@ -5,20 +5,18 @@ import bgg.domain.{GameData, GameId}
 import java.time.Instant
 import scala.collection.concurrent.TrieMap
 
-class MemoryGameCache(ttlSeconds: Int) extends GameCache:
-  private val store: TrieMap[Int, (GameData, Long)] = TrieMap.empty
+class MemoryGameCache extends GameCache:
+  private val store: TrieMap[Int, (GameData, Instant)] = TrieMap.empty
 
-  def save(game: GameData): Unit =
-    store.putIfAbsent(game.id.value, (game, Instant.now().getEpochSecond)): Unit
+  def save(game: GameData, now: Instant): Unit =
+    store.putIfAbsent(game.id.value, (game, now)): Unit
 
   def load(id: GameId): Option[GameData] =
-    store
-      .updateWith(id.value) {
-        case Some((game, ts)) if Instant.now().getEpochSecond - ts < ttlSeconds => Some((game, ts))
-        case _                                                                  => None
-      }
-      .map(_._1)
+    val now = Instant.now()
+    store.get(id.value).collect {
+      case (game, cachedAt) if !AdaptiveTtl.isExpired(cachedAt, game.yearPublished, now) => game
+    }
 
   def evictExpired(): Unit =
-    val cutoff = Instant.now().getEpochSecond - ttlSeconds
-    store.filterInPlace((_, v) => v._2 >= cutoff)
+    val now = Instant.now()
+    store.filterInPlace((_, v) => !AdaptiveTtl.isExpired(v._2, v._1.yearPublished, now))

--- a/src/main/scala/bgg/cache/SqliteGameCache.scala
+++ b/src/main/scala/bgg/cache/SqliteGameCache.scala
@@ -1,58 +1,64 @@
 package bgg.cache
 
-import bgg.SafeOps.{decodeJson, withStatement}
+import bgg.SafeOps.{decodeJson, resultSetIterator, withStatement}
+import bgg.SqliteStore
 import bgg.domain.{GameData, GameId}
-import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
 
-import java.sql.{Connection, DriverManager}
 import java.time.Instant
 
-class SqliteGameCache(dbPath: String, ttlSeconds: Int) extends GameCache with AutoCloseable with StrictLogging:
-  private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
-  prepareSchema()
-
-  private given Logger = logger
-
-  def close(): Unit = conn.close()
-
-  private def prepareSchema(): Unit =
-    val sql =
+class SqliteGameCache(dbPath: String)
+    extends SqliteStore(
+      dbPath,
       """CREATE TABLE IF NOT EXISTS cached_game (
          id TEXT NOT NULL PRIMARY KEY,
          cache_timestamp INTEGER NOT NULL,
          data TEXT NOT NULL)"""
-    val stmt = conn.createStatement()
-    stmt.execute(sql)
-    stmt.close()
+    )
+    with GameCache:
 
-  def save(game: GameData): Unit =
+  def save(game: GameData, now: Instant): Unit =
     val sql =
       "INSERT INTO cached_game (id, cache_timestamp, data) SELECT ?,?,? WHERE NOT EXISTS(SELECT 1 FROM cached_game WHERE id=?)"
     withStatement(conn, sql) { ps =>
       ps.setString(1, game.id.asString)
-      ps.setLong(2, Instant.now().getEpochSecond)
+      ps.setLong(2, now.getEpochSecond)
       ps.setString(3, game.asJson.noSpaces)
       ps.setString(4, game.id.asString)
-      ps.executeUpdate()
+      ps.executeUpdate(): Unit
     }
     logger.debug(s"Cached game ${game.id.value} (${game.name})")
 
   def load(id: GameId): Option[GameData] =
-    withStatement(conn, "SELECT data FROM cached_game WHERE id=?") { ps =>
+    withStatement(conn, "SELECT cache_timestamp, data FROM cached_game WHERE id=?") { ps =>
       ps.setString(1, id.asString)
       val rs = ps.executeQuery()
       val result =
-        if rs.next() then decodeJson[GameData](rs.getString(1), s"game $id from cache")
+        if rs.next() then
+          val cachedAt = Instant.ofEpochSecond(rs.getLong(1))
+          decodeJson[GameData](rs.getString(2), s"game $id from cache").filter { game =>
+            !AdaptiveTtl.isExpired(cachedAt, game.yearPublished, Instant.now())
+          }
         else None
       rs.close()
       result
     }
 
   def evictExpired(): Unit =
-    val cutoff = Instant.now().getEpochSecond - ttlSeconds
-    withStatement(conn, "DELETE FROM cached_game WHERE cache_timestamp < ?") { ps =>
-      ps.setLong(1, cutoff)
-      val deleted = ps.executeUpdate()
-      if deleted > 0 then logger.info(s"Evicted $deleted expired games from cache")
+    withStatement(conn, "SELECT id, cache_timestamp, data FROM cached_game") { ps =>
+      val rs = ps.executeQuery()
+      val now = Instant.now()
+      val expired = resultSetIterator(rs).flatMap { r =>
+        val cachedAt = Instant.ofEpochSecond(r.getLong(2))
+        decodeJson[GameData](r.getString(3), "game from cache").collect {
+          case game if AdaptiveTtl.isExpired(cachedAt, game.yearPublished, now) => r.getString(1)
+        }
+      }.toList
+      rs.close()
+      if expired.nonEmpty then
+        withStatement(conn, s"DELETE FROM cached_game WHERE id IN (${expired.map(_ => "?").mkString(",")})") { del =>
+          expired.zipWithIndex.foreach { (id, i) => del.setString(i + 1, id) }
+          val deleted = del.executeUpdate()
+          logger.info(s"Evicted $deleted expired games from cache")
+        }
     }

--- a/src/main/scala/bgg/lambda/ApiHandler.scala
+++ b/src/main/scala/bgg/lambda/ApiHandler.scala
@@ -1,7 +1,7 @@
 package bgg.lambda
 
 import bgg.bggapi.{BggXmlClient, GameService}
-import bgg.cache.{DynamoDbGameCache, MemoryGameCache, SqliteGameCache}
+import bgg.cache.{DynamoDbGameCache, DynamoDbRequestCache, MemoryGameCache, NoOpRequestCache, SqliteGameCache}
 import bgg.config.{AppConfig, CacheBackend}
 import bgg.prefetch.{DynamoDbPrefetchStatusStore, SqlitePrefetchStatusStore}
 import bgg.routes.{ApiEndpoints, AwsSqsSender, ErrorOutput, NoOpSqsSender}
@@ -9,9 +9,11 @@ import bgg.store.{DynamoDbVectorStore, SqliteVectorStore}
 import com.typesafe.scalalogging.StrictLogging
 import ox.*
 import sttp.client4.DefaultSyncBackend
+import sttp.tapir.server.interceptor.cors.{CORSConfig, CORSInterceptor}
 import sttp.tapir.server.netty.sync.NettySyncServer
 import sttp.tapir.server.netty.sync.NettySyncServerOptions
 import sttp.tapir.server.model.ValuedEndpointOutput
+import sttp.shared.Identity
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.sqs.SqsClient
@@ -32,7 +34,7 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
     val httpBackend = useInScope(DefaultSyncBackend())(_.close())
     val bggClient = BggXmlClient(config.bgg, httpBackend)
 
-    val (gameCache, vectorStore, prefetchStore, sqsSender) = config.cache.backend match
+    val (gameCache, vectorStore, prefetchStore, sqsSender, requestCache) = config.cache.backend match
       case CacheBackend.DynamoDB =>
         val dynamo = useInScope(
           DynamoDbClient
@@ -49,34 +51,40 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
             .build()
         )(_.close())
         (
-          DynamoDbGameCache(dynamo, config.aws.dynamoGameTable, config.cache.gameCacheTtlSeconds),
+          DynamoDbGameCache(dynamo, config.aws.dynamoGameTable),
           DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable),
           DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable),
-          AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
+          AwsSqsSender(sqs, config.aws.prefetchSqsUrl),
+          DynamoDbRequestCache(dynamo, config.aws.dynamoRequestTable)
         )
 
       case CacheBackend.SQLite =>
         (
-          SqliteGameCache(config.cache.sqliteGameCachePath, config.cache.gameCacheTtlSeconds),
+          SqliteGameCache(config.cache.sqliteGameCachePath),
           SqliteVectorStore(config.cache.sqliteVectorStorePath),
           SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
-          NoOpSqsSender()
+          NoOpSqsSender(),
+          NoOpRequestCache()
         )
 
       case CacheBackend.Memory =>
         (
-          MemoryGameCache(config.cache.gameCacheTtlSeconds),
+          MemoryGameCache(),
           SqliteVectorStore(config.cache.sqliteVectorStorePath),
           SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
-          NoOpSqsSender()
+          NoOpSqsSender(),
+          NoOpRequestCache()
         )
 
     val gameService =
-      GameService(bggClient, gameCache, vectorStore, config.cache.vectorMinRatings, () => Instant.now())
+      GameService(bggClient, gameCache, vectorStore, requestCache, config.cache.vectorMinRatings, () => Instant.now())
     ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, sqsSender, config)
 
   private def startServer(endpoints: ApiEndpoints, config: AppConfig): Unit =
     val serverOptions = NettySyncServerOptions.customiseInterceptors
+      .corsInterceptor(CORSInterceptor.customOrThrow[Identity](
+        CORSConfig.default.maxAge(scala.concurrent.duration.Duration(1, "day"))
+      ))
       .defaultHandlers(
         msg =>
           if msg == "Not Found" then ValuedEndpointOutput(ErrorOutput.failOutput, bgg.domain.Fail.NotFound(msg))

--- a/src/main/scala/bgg/lambda/NativeBootstrap.scala
+++ b/src/main/scala/bgg/lambda/NativeBootstrap.scala
@@ -18,8 +18,10 @@ object NativeBootstrap:
 
   private val corsHeaders = Map(
     "Access-Control-Allow-Origin" -> "*",
-    "Access-Control-Allow-Methods" -> "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers" -> "Content-Type, Bgg-Filter-Player-Count, Bgg-Filter-Using-Recommended-Players, Bgg-Filter-Min-Duration, Bgg-Filter-Max-Duration, Bgg-Filter-Complexity, Bgg-Filter-Min-Rating, Bgg-Filter-Mechanic, Bgg-Include-Expansions, Bgg-Field-Whitelist"
+    "Access-Control-Allow-Methods" -> "GET, HEAD, POST, OPTIONS",
+    "Access-Control-Allow-Headers" -> "Content-Type, Bgg-Filter-Player-Count, Bgg-Filter-Using-Recommended-Players, Bgg-Filter-Min-Duration, Bgg-Filter-Max-Duration, Bgg-Filter-Complexity, Bgg-Filter-Min-Rating, Bgg-Filter-Mechanic, Bgg-Include-Expansions, Bgg-Field-Whitelist",
+    "Access-Control-Max-Age" -> "86400",
+    "Vary" -> "Accept-Encoding"
   )
 
   private def buildApiRoute(): String => String =

--- a/src/main/scala/bgg/prefetch/DynamoDbPrefetchStatusStore.scala
+++ b/src/main/scala/bgg/prefetch/DynamoDbPrefetchStatusStore.scala
@@ -51,4 +51,4 @@ class DynamoDbPrefetchStatusStore(client: DynamoDbClient, tableName: String)
     tryAwsCall(
       client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build()),
       "Failed to write prefetch status to DynamoDB"
-    )
+    ): Unit

--- a/src/main/scala/bgg/prefetch/SqlitePrefetchStatusStore.scala
+++ b/src/main/scala/bgg/prefetch/SqlitePrefetchStatusStore.scala
@@ -1,22 +1,14 @@
 package bgg.prefetch
 
 import bgg.SafeOps.{trySqlCall, withStatement}
+import bgg.SqliteStore
 import bgg.domain.SourceType
-import com.typesafe.scalalogging.{Logger, StrictLogging}
 
-import java.sql.{Connection, DriverManager}
 import java.time.Instant
 
-class SqlitePrefetchStatusStore(dbPath: String) extends PrefetchStatusStore with AutoCloseable with StrictLogging:
-  private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
-  prepareSchema()
-
-  private given Logger = logger
-
-  def close(): Unit = conn.close()
-
-  private def prepareSchema(): Unit =
-    val sql =
+class SqlitePrefetchStatusStore(dbPath: String)
+    extends SqliteStore(
+      dbPath,
       """CREATE TABLE IF NOT EXISTS prefetch_status (
          id TEXT NOT NULL PRIMARY KEY,
          source_type TEXT NOT NULL,
@@ -24,9 +16,8 @@ class SqlitePrefetchStatusStore(dbPath: String) extends PrefetchStatusStore with
          status TEXT NOT NULL,
          reason TEXT NOT NULL DEFAULT '',
          expires_at INTEGER NOT NULL)"""
-    val stmt = conn.createStatement()
-    stmt.execute(sql)
-    stmt.close()
+    )
+    with PrefetchStatusStore:
 
   def get(sourceType: SourceType, sourceId: String): Option[PrefetchRecord] =
     withStatement(conn, "SELECT source_type, source_id, status, reason, expires_at FROM prefetch_status WHERE id=?") {
@@ -35,13 +26,12 @@ class SqlitePrefetchStatusStore(dbPath: String) extends PrefetchStatusStore with
         val rs = ps.executeQuery()
         val result =
           if rs.next() then
-            val expiresAt = Instant.ofEpochSecond(rs.getLong(5))
             val record = PrefetchRecord(
               sourceType = SourceType.fromString(rs.getString(1)).getOrElse(sourceType),
               sourceId = rs.getString(2),
               status = PrefetchStatus.fromDbKey(rs.getString(3)),
               reason = rs.getString(4),
-              expiresAt = expiresAt
+              expiresAt = Instant.ofEpochSecond(rs.getLong(5))
             )
             Option.when(!record.isExpired)(record)
           else None
@@ -62,7 +52,7 @@ class SqlitePrefetchStatusStore(dbPath: String) extends PrefetchStatusStore with
         ps.setString(4, status.dbKey)
         ps.setString(5, reason)
         ps.setLong(6, PrefetchTtl.expiresAt(status).getEpochSecond)
-        ps.executeUpdate()
+        ps.executeUpdate(): Unit
       },
       "Failed to write prefetch status"
     )

--- a/src/main/scala/bgg/store/DynamoDbVectorStore.scala
+++ b/src/main/scala/bgg/store/DynamoDbVectorStore.scala
@@ -26,7 +26,7 @@ class DynamoDbVectorStore(client: DynamoDbClient, tableName: String) extends Vec
     tryAwsCall(
       client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build()),
       s"Error saving vector for game ${sv.gameId.value}"
-    )
+    ): Unit
 
   def load(id: GameId): Option[StoredVector] =
     tryAwsCall(

--- a/src/main/scala/bgg/store/SqliteVectorStore.scala
+++ b/src/main/scala/bgg/store/SqliteVectorStore.scala
@@ -1,32 +1,24 @@
 package bgg.store
 
-import bgg.SafeOps.{decodeJson, withStatement}
+import bgg.SafeOps.{decodeJson, resultSetIterator, withStatement}
+import bgg.SqliteStore
 import bgg.domain.GameId
 import bgg.vector.GameVector
-import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
 
-import java.sql.{Connection, DriverManager}
+import java.sql.ResultSet
 import java.time.Instant
 
-class SqliteVectorStore(dbPath: String) extends VectorStore with AutoCloseable with StrictLogging:
-  private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:$dbPath")
-  prepareSchema()
-
-  private given Logger = logger
-
-  def close(): Unit = conn.close()
-
-  private def prepareSchema(): Unit =
-    val sql =
+class SqliteVectorStore(dbPath: String)
+    extends SqliteStore(
+      dbPath,
       """CREATE TABLE IF NOT EXISTS game_vectors (
          game_id INTEGER NOT NULL PRIMARY KEY,
          name TEXT NOT NULL,
          vector TEXT NOT NULL,
          updated_at TEXT NOT NULL)"""
-    val stmt = conn.createStatement()
-    stmt.execute(sql)
-    stmt.close()
+    )
+    with VectorStore:
 
   def save(sv: StoredVector): Unit =
     withStatement(conn, "INSERT OR REPLACE INTO game_vectors (game_id, name, vector, updated_at) VALUES (?,?,?,?)") {
@@ -35,7 +27,7 @@ class SqliteVectorStore(dbPath: String) extends VectorStore with AutoCloseable w
         ps.setString(2, sv.name)
         ps.setString(3, sv.vector.values.asJson.noSpaces)
         ps.setString(4, sv.updatedAt.toString)
-        ps.executeUpdate()
+        ps.executeUpdate(): Unit
     }
 
   def load(id: GameId): Option[StoredVector] =
@@ -50,12 +42,12 @@ class SqliteVectorStore(dbPath: String) extends VectorStore with AutoCloseable w
   def loadAll(): List[StoredVector] =
     withStatement(conn, "SELECT game_id, name, vector, updated_at FROM game_vectors") { ps =>
       val rs = ps.executeQuery()
-      val results = Iterator.continually(rs).takeWhile(_.next()).flatMap(rowToStoredVector).toList
+      val results = resultSetIterator(rs).flatMap(rowToStoredVector).toList
       rs.close()
       results
     }
 
-  private def rowToStoredVector(rs: java.sql.ResultSet): Option[StoredVector] =
+  private def rowToStoredVector(rs: ResultSet): Option[StoredVector] =
     decodeJson[Vector[Double]](rs.getString(3), s"vector for game ${rs.getInt(1)}").map { vec =>
       StoredVector(
         gameId = GameId(rs.getInt(1)),


### PR DESCRIPTION
Add a CloudFront distribution in front of API Gateway to cache cors-proxy image responses at the edge, avoiding hot-linking BGG images on every request. Uses CachingOptimized policy for /cors-proxy/* (respects existing 1-year immutable Cache-Control headers) and CachingDisabled for all other API routes. PriceClass_100 keeps costs within free tier.

Also refactors the SQLite data access layer: extract SqliteStore base trait to eliminate duplicated connection/schema/close boilerplate, replace mutable ListBuffer with functional Iterator in evictExpired, remove side-effectful updateWith in MemoryGameCache.load, and fix all 6 compiler warnings (unused import, discarded values).

Bumps version to 3.3.0.