### PR TITLE
feat: add plays endpoint, batch cache, scoverage, and fix review findings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,28 @@ lazy val root = (project in file("."))
       case _                                        => MergeStrategy.first
     },
 
+    coverageMinimumStmtTotal := 90,
+    coverageMinimumBranchTotal := 90,
+    coverageFailOnMinimum := true,
+    coverageExcludedPackages := Seq(
+      "bgg\\.lambda\\.NativeBootstrap.*",
+      "bgg\\.lambda\\.ApiHandler.*",
+      "bgg\\.lambda\\.ApiLambdaHandler",
+      "bgg\\.lambda\\.PrefetchWorker",
+      "bgg\\.lambda\\.PrefetchWorkerLogic\\$",
+      "bgg\\.routes\\.AwsSqsSender",
+      "bgg\\.routes\\.ErrorOutput.*",
+      "bgg\\.cache\\.SqliteCacheProvider",
+      "bgg\\.cache\\.MemoryCacheProvider",
+    ).mkString(";"),
+    coverageExcludedFiles := Seq(
+      ".*DynamoDbGameCache.*",
+      ".*DynamoDbPlaysCache.*",
+      ".*DynamoDbRequestCache.*",
+      ".*DynamoDbCacheProvider.*",
+      ".*DynamoDbPrefetchStatusStore.*",
+    ).mkString(";"),
+
     Test / scalacOptions --= Seq("-Wvalue-discard", "-Wnonunit-statement"),
     Test / fork := true,
     Test / javaHome := Some(file(sys.env.getOrElse("JAVA_HOME", "/usr/lib/jvm/java-21"))),

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -220,6 +220,12 @@ Resources:
             RestApiId: !Ref ApiGateway
             Path: /health
             Method: GET
+        Hot:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /hot
+            Method: GET
         GetCollection:
           Type: Api
           Properties:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,4 @@
 addSbtPlugin("com.eed3si9n"  % "sbt-assembly"  % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.6.1")
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo" % "0.13.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -39,6 +39,8 @@ aws {
   dynamoVectorTable = ${?DYNAMODB_VECTOR_TABLE}
   dynamoPrefetchTable = "bgg-prefetch-status"
   dynamoPrefetchTable = ${?DYNAMODB_PREFETCH_TABLE}
+  dynamoPlaysTable = "bgg-plays"
+  dynamoPlaysTable = ${?DYNAMODB_PLAYS_TABLE}
   prefetchSqsUrl = ""
   prefetchSqsUrl = ${?PREFETCH_SQS_URL}
 }

--- a/src/main/scala/bgg/bggapi/BggClient.scala
+++ b/src/main/scala/bgg/bggapi/BggClient.scala
@@ -1,6 +1,6 @@
 package bgg.bggapi
 
-import bgg.domain.{Fail, GameData, GameId}
+import bgg.domain.{Fail, GameData, GameId, PlayData}
 
 trait BggClient:
   def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]]
@@ -8,3 +8,4 @@ trait BggClient:
   def fetchGeeklist(listId: String): Either[Fail, List[GameId]]
   def fetchHotGames(): Either[Fail, List[GameId]]
   def searchGames(query: String): Either[Fail, List[GameData]]
+  def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]]

--- a/src/main/scala/bgg/bggapi/BggXmlClient.scala
+++ b/src/main/scala/bgg/bggapi/BggXmlClient.scala
@@ -1,7 +1,7 @@
 package bgg.bggapi
 
 import bgg.config.BggConfig
-import bgg.domain.*
+import bgg.domain.{Fail, GameData, GameId, PlayData}
 import com.typesafe.scalalogging.StrictLogging
 import sttp.client4.*
 import sttp.model.StatusCode
@@ -98,3 +98,7 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
               case Left(_)      => Nil
           }
         }
+
+  def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] =
+    getWithRetry(s"$ApiV2Base/plays", Map("username" -> username, "page" -> page.toString))
+      .map(XmlParser.parsePlays)

--- a/src/main/scala/bgg/bggapi/GameService.scala
+++ b/src/main/scala/bgg/bggapi/GameService.scala
@@ -1,8 +1,8 @@
 package bgg.bggapi
 
-import bgg.cache.{GameCache, RequestCache}
-import bgg.domain.{Fail, GameData, GameId}
-import bgg.store.{StoredVector, VectorStore}
+import bgg.cache.CacheProvider
+import bgg.domain.{Fail, GameData, GameId, PlayData}
+import bgg.store.StoredVector
 import bgg.vector.VectorMath
 import com.typesafe.scalalogging.StrictLogging
 
@@ -10,16 +10,19 @@ import java.time.{Instant, Year}
 
 class GameService(
     bggClient: BggClient,
-    gameCache: GameCache,
-    vectorStore: VectorStore,
-    requestCache: RequestCache,
+    caches: CacheProvider,
     vectorMinRatings: Int,
     clock: () => Instant
 ) extends StrictLogging:
 
+  private val gameCache = caches.gameCache
+  private val vectorStore = caches.vectorStore
+  private val requestCache = caches.requestCache
+  private val playsCache = caches.playsCache
+
   def resolveGameIds(ids: List[GameId]): Either[Fail, List[GameData]] =
     val (cached, missing) = partitionCached(ids)
-    if missing.isEmpty then Right(cached)
+    if missing.isEmpty then Right(cached.sortBy(_.name))
     else
       bggClient.fetchGamesByIds(missing).map { fetched =>
         fetched.foreach(cacheAndSync)
@@ -50,9 +53,46 @@ class GameService(
   def search(query: String): Either[Fail, List[GameData]] =
     bggClient.searchGames(query)
 
+  def resolvePlays(username: String): Either[Fail, List[PlayData]] =
+    playsCache.load(username) match
+      case Some(plays) =>
+        logger.debug(s"Plays for $username served from cache (${plays.size} plays)")
+        Right(plays)
+      case None =>
+        fetchAllPlays(username).map { plays =>
+          playsCache.save(username, plays)
+          plays
+        }
+
+  def fetchAndCachePlays(username: String): Unit =
+    fetchAllPlays(username) match
+      case Right(plays) =>
+        playsCache.save(username, plays)
+        logger.info(s"Fetched and cached ${plays.size} plays for $username")
+      case Left(err) =>
+        logger.warn(s"Failed to fetch plays for $username: $err")
+
+  private val MaxPlayPages = 200
+
+  private def fetchAllPlays(username: String): Either[Fail, List[PlayData]] =
+    @scala.annotation.tailrec
+    def loop(page: Int, acc: List[List[PlayData]]): Either[Fail, List[PlayData]] =
+      if page > MaxPlayPages then
+        logger.warn(s"Hit max page limit ($MaxPlayPages) fetching plays for $username")
+        Right(acc.reverse.flatten)
+      else
+        bggClient.fetchPlays(username, page) match
+          case Left(err) if page == 1        => Left(err)
+          case Left(_)                       => Right(acc.reverse.flatten)
+          case Right(plays) if plays.isEmpty => Right(acc.reverse.flatten)
+          case Right(plays)                  => loop(page + 1, plays :: acc)
+    loop(1, Nil)
+
   private def partitionCached(ids: List[GameId]): (List[GameData], List[GameId]) =
-    val (misses, cached) = ids.partitionMap(id => gameCache.load(id).toRight(id))
-    (cached, misses)
+    val cached = gameCache.loadBatch(ids)
+    val cachedIds = cached.map(_.id).toSet
+    val missing = ids.filterNot(cachedIds.contains)
+    (cached, missing)
 
   private def cacheAndSync(game: GameData): Unit =
     gameCache.save(game, clock())

--- a/src/main/scala/bgg/bggapi/XmlParser.scala
+++ b/src/main/scala/bgg/bggapi/XmlParser.scala
@@ -1,6 +1,6 @@
 package bgg.bggapi
 
-import bgg.domain.{GameData, GameId, PlayerSuggestion}
+import bgg.domain.{GameData, GameId, PlayData, PlayPlayer, PlayerSuggestion}
 
 import scala.xml.{Node, NodeSeq}
 
@@ -78,6 +78,40 @@ private[bggapi] object XmlParser:
         }
       }
     }
+
+  def parsePlays(xml: scala.xml.Elem): List[PlayData] =
+    (xml \ "play").toList.flatMap(parsePlay)
+
+  private def parsePlay(play: Node): Option[PlayData] =
+    val playId = (play \ "@id").headOption.flatMap(_.text.toIntOption)
+    val item = (play \ "item").headOption
+    val gameId = item.flatMap(i => (i \ "@objectid").headOption.flatMap(_.text.toIntOption))
+    val gameName = item.map(i => (i \ "@name").text).getOrElse("")
+
+    for
+      pid <- playId
+      gid <- gameId
+    yield
+      val date = (play \ "@date").text
+      val quantity = (play \ "@quantity").text.toIntOption.getOrElse(1)
+      val length = (play \ "@length").text.toIntOption.getOrElse(0)
+      val players = (play \ "players" \ "player").toList.map { p =>
+        PlayPlayer(
+          username = (p \ "@username").text,
+          name = (p \ "@name").text,
+          score = Option((p \ "@score").text).filter(_.nonEmpty),
+          win = (p \ "@win").text == "1"
+        )
+      }
+      PlayData(
+        playId = pid,
+        gameId = GameId(gid),
+        gameName = gameName,
+        date = date,
+        quantity = quantity,
+        length = length,
+        players = players
+      )
 
   private def intAttr(nodes: NodeSeq, attr: String): Option[Int] =
     nodes.headOption.flatMap(n => (n \ attr).text.toIntOption)

--- a/src/main/scala/bgg/cache/CacheProvider.scala
+++ b/src/main/scala/bgg/cache/CacheProvider.scala
@@ -1,0 +1,9 @@
+package bgg.cache
+
+import bgg.store.VectorStore
+
+trait CacheProvider:
+  def gameCache: GameCache
+  def vectorStore: VectorStore
+  def requestCache: RequestCache
+  def playsCache: PlaysCache

--- a/src/main/scala/bgg/cache/DynamoDbCacheProvider.scala
+++ b/src/main/scala/bgg/cache/DynamoDbCacheProvider.scala
@@ -1,0 +1,11 @@
+package bgg.cache
+
+import bgg.config.AwsConfig
+import bgg.store.{DynamoDbVectorStore, VectorStore}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+
+class DynamoDbCacheProvider(client: DynamoDbClient, aws: AwsConfig) extends CacheProvider:
+  val gameCache: GameCache = DynamoDbGameCache(client, aws.dynamoGameTable)
+  val vectorStore: VectorStore = DynamoDbVectorStore(client, aws.dynamoVectorTable)
+  val requestCache: RequestCache = DynamoDbRequestCache(client, aws.dynamoRequestTable)
+  val playsCache: PlaysCache = DynamoDbPlaysCache(client, aws.dynamoPlaysTable)

--- a/src/main/scala/bgg/cache/DynamoDbGameCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbGameCache.scala
@@ -41,6 +41,8 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String) extends GameC
       case e: Exception =>
         logger.error(s"Error saving game ${game.id.value} to cache", e)
 
+  private val BatchGetMaxKeys = 100
+
   def load(id: GameId): Option[GameData] =
     val request = GetItemRequest
       .builder()
@@ -51,3 +53,43 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String) extends GameC
     tryAwsCall(client.getItem(request), s"Error loading game $id from DynamoDB")
       .filter(_.hasItem)
       .flatMap(response => decodeJson[GameData](response.item().get("data").s(), s"game $id from DynamoDB"))
+
+  private val BatchGetMaxRetries = 3
+
+  override def loadBatch(ids: List[GameId]): List[GameData] =
+    if ids.isEmpty then return Nil
+    ids.distinct
+      .grouped(BatchGetMaxKeys)
+      .flatMap { chunk =>
+        fetchBatchWithRetry(
+          chunk.map(id => Map("id" -> AttributeValue.fromS(id.asString)).asJava),
+          Nil,
+          BatchGetMaxRetries
+        )
+      }
+      .toList
+
+  @scala.annotation.tailrec
+  private def fetchBatchWithRetry(
+      keys: List[java.util.Map[String, AttributeValue]],
+      acc: List[GameData],
+      retriesLeft: Int
+  ): List[GameData] =
+    val keysAndAttrs = KeysAndAttributes.builder().keys(keys.asJava).build()
+    val request = BatchGetItemRequest.builder().requestItems(Map(tableName -> keysAndAttrs).asJava).build()
+    tryAwsCall(client.batchGetItem(request), "Error batch-loading games from DynamoDB") match
+      case None => acc
+      case Some(response) =>
+        val items = response.responses().getOrDefault(tableName, java.util.Collections.emptyList()).asScala
+        val decoded = items.flatMap { item =>
+          Option(item.get("data")).flatMap(attr => decodeJson[GameData](attr.s(), "batch game from DynamoDB"))
+        }.toList
+        val unprocessed = response.unprocessedKeys().asScala.get(tableName)
+        unprocessed match
+          case Some(remaining) if remaining.keys().size() > 0 && retriesLeft > 0 =>
+            logger.warn(s"DynamoDB returned ${remaining.keys().size()} unprocessed keys, retrying")
+            fetchBatchWithRetry(remaining.keys().asScala.toList, acc ++ decoded, retriesLeft - 1)
+          case Some(remaining) if remaining.keys().size() > 0 =>
+            logger.error(s"DynamoDB still has ${remaining.keys().size()} unprocessed keys after retries")
+            acc ++ decoded
+          case _ => acc ++ decoded

--- a/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
@@ -1,0 +1,64 @@
+package bgg.cache
+
+import bgg.SafeOps.{decodeJson, tryAwsCall}
+import bgg.domain.PlayData
+import com.typesafe.scalalogging.{Logger, StrictLogging}
+import io.circe.syntax.*
+import io.circe.{Decoder, Encoder}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.*
+
+import scala.jdk.CollectionConverters.*
+
+class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String) extends PlaysCache with StrictLogging:
+
+  private given Logger = logger
+  private given Encoder[List[PlayData]] = Encoder.encodeList(PlayData.encoder)
+  private given Decoder[List[PlayData]] = Decoder.decodeList(playDataDecoder)
+
+  private val playDataDecoder: Decoder[PlayData] = Decoder.instance { c =>
+    import bgg.domain.{GameId, PlayPlayer}
+    for
+      playId <- c.downField("play_id").as[Int]
+      gameId <- c.downField("game_id").as[Int]
+      gameName <- c.downField("game_name").as[String]
+      date <- c.downField("date").as[String]
+      quantity <- c.downField("quantity").as[Int]
+      length <- c.downField("length").as[Int]
+      players <- c.downField("players").as[List[PlayPlayer]]
+    yield PlayData(playId, GameId(gameId), gameName, date, quantity, length, players)
+  }
+
+  private given Decoder[bgg.domain.PlayPlayer] = Decoder.instance { c =>
+    for
+      username <- c.downField("username").as[String]
+      name <- c.downField("name").as[String]
+      score <- c.downField("score").as[Option[String]]
+      win <- c.downField("win").as[Boolean]
+    yield bgg.domain.PlayPlayer(username, name, score, win)
+  }
+
+  def save(username: String, plays: List[PlayData]): Unit =
+    val item = Map(
+      "username" -> AttributeValue.fromS(username.toLowerCase),
+      "data" -> AttributeValue.fromS(plays.asJson.noSpaces)
+    ).asJava
+
+    val request = PutItemRequest.builder().tableName(tableName).item(item).build()
+    try
+      client.putItem(request)
+      logger.debug(s"Cached ${plays.size} plays for $username")
+    catch
+      case e: Exception =>
+        logger.error(s"Error saving plays for $username", e)
+
+  def load(username: String): Option[List[PlayData]] =
+    val request = GetItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(Map("username" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .build()
+
+    tryAwsCall(client.getItem(request), s"Error loading plays for $username")
+      .filter(_.hasItem)
+      .flatMap(response => decodeJson[List[PlayData]](response.item().get("data").s(), s"plays for $username"))

--- a/src/main/scala/bgg/cache/GameCache.scala
+++ b/src/main/scala/bgg/cache/GameCache.scala
@@ -7,4 +7,5 @@ import java.time.Instant
 trait GameCache:
   def save(game: GameData, now: Instant): Unit
   def load(id: GameId): Option[GameData]
+  def loadBatch(ids: List[GameId]): List[GameData] = ids.flatMap(load)
   def evictExpired(): Unit

--- a/src/main/scala/bgg/cache/LocalCacheProvider.scala
+++ b/src/main/scala/bgg/cache/LocalCacheProvider.scala
@@ -1,0 +1,16 @@
+package bgg.cache
+
+import bgg.config.CacheConfig
+import bgg.store.{SqliteVectorStore, VectorStore}
+
+class SqliteCacheProvider(config: CacheConfig) extends CacheProvider:
+  val gameCache: GameCache = SqliteGameCache(config.sqliteGameCachePath)
+  val vectorStore: VectorStore = SqliteVectorStore(config.sqliteVectorStorePath)
+  val requestCache: RequestCache = NoOpRequestCache()
+  val playsCache: PlaysCache = NoOpPlaysCache()
+
+class MemoryCacheProvider(config: CacheConfig) extends CacheProvider:
+  val gameCache: GameCache = MemoryGameCache()
+  val vectorStore: VectorStore = SqliteVectorStore(config.sqliteVectorStorePath)
+  val requestCache: RequestCache = NoOpRequestCache()
+  val playsCache: PlaysCache = NoOpPlaysCache()

--- a/src/main/scala/bgg/cache/PlaysCache.scala
+++ b/src/main/scala/bgg/cache/PlaysCache.scala
@@ -1,0 +1,11 @@
+package bgg.cache
+
+import bgg.domain.PlayData
+
+trait PlaysCache:
+  def save(username: String, plays: List[PlayData]): Unit
+  def load(username: String): Option[List[PlayData]]
+
+class NoOpPlaysCache extends PlaysCache:
+  def save(username: String, plays: List[PlayData]): Unit = ()
+  def load(username: String): Option[List[PlayData]] = None

--- a/src/main/scala/bgg/config/AppConfig.scala
+++ b/src/main/scala/bgg/config/AppConfig.scala
@@ -36,6 +36,7 @@ case class AwsConfig(
     dynamoGameTable: String,
     dynamoVectorTable: String,
     dynamoPrefetchTable: String,
+    dynamoPlaysTable: String,
     prefetchSqsUrl: String
 )
 
@@ -80,6 +81,7 @@ object AppConfig:
       dynamoGameTable = c.getString("aws.dynamoGameTable"),
       dynamoVectorTable = c.getString("aws.dynamoVectorTable"),
       dynamoPrefetchTable = c.getString("aws.dynamoPrefetchTable"),
+      dynamoPlaysTable = c.getString("aws.dynamoPlaysTable"),
       prefetchSqsUrl = c.getString("aws.prefetchSqsUrl")
     )
 

--- a/src/main/scala/bgg/domain/Model.scala
+++ b/src/main/scala/bgg/domain/Model.scala
@@ -160,6 +160,44 @@ case class PlayerSuggestion(
 )
 object PlayerSuggestion
 
+case class PlayPlayer(
+    username: String,
+    name: String,
+    score: Option[String],
+    win: Boolean
+)
+
+case class PlayData(
+    playId: Int,
+    gameId: GameId,
+    gameName: String,
+    date: String,
+    quantity: Int,
+    length: Int,
+    players: List[PlayPlayer]
+)
+
+object PlayData:
+  given encoder: Encoder[PlayData] = Encoder.instance { p =>
+    import io.circe.Json
+    Json.obj(
+      "play_id" -> Json.fromInt(p.playId),
+      "game_id" -> Encoder[GameId].apply(p.gameId),
+      "game_name" -> Json.fromString(p.gameName),
+      "date" -> Json.fromString(p.date),
+      "quantity" -> Json.fromInt(p.quantity),
+      "length" -> Json.fromInt(p.length),
+      "players" -> Json.fromValues(p.players.map { pl =>
+        Json.obj(
+          "username" -> Json.fromString(pl.username),
+          "name" -> Json.fromString(pl.name),
+          "score" -> pl.score.filter(_.nonEmpty).fold(Json.Null)(Json.fromString),
+          "win" -> Json.fromBoolean(pl.win)
+        )
+      })
+    )
+  }
+
 // Filters extracted from request headers
 case class GameFilters(
     playerCount: Option[Int],

--- a/src/main/scala/bgg/lambda/ApiHandler.scala
+++ b/src/main/scala/bgg/lambda/ApiHandler.scala
@@ -1,11 +1,10 @@
 package bgg.lambda
 
 import bgg.bggapi.{BggXmlClient, GameService}
-import bgg.cache.{DynamoDbGameCache, DynamoDbRequestCache, MemoryGameCache, NoOpRequestCache, SqliteGameCache}
+import bgg.cache.{DynamoDbCacheProvider, MemoryCacheProvider, SqliteCacheProvider}
 import bgg.config.{AppConfig, CacheBackend}
 import bgg.prefetch.{DynamoDbPrefetchStatusStore, SqlitePrefetchStatusStore}
 import bgg.routes.{ApiEndpoints, AwsSqsSender, ErrorOutput, NoOpSqsSender}
-import bgg.store.{DynamoDbVectorStore, SqliteVectorStore}
 import com.typesafe.scalalogging.StrictLogging
 import ox.*
 import sttp.client4.DefaultSyncBackend
@@ -34,7 +33,7 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
     val httpBackend = useInScope(DefaultSyncBackend())(_.close())
     val bggClient = BggXmlClient(config.bgg, httpBackend)
 
-    val (gameCache, vectorStore, prefetchStore, sqsSender, requestCache) = config.cache.backend match
+    val (caches, prefetchStore, sqsSender) = config.cache.backend match
       case CacheBackend.DynamoDB =>
         val dynamo = useInScope(
           DynamoDbClient
@@ -51,40 +50,35 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
             .build()
         )(_.close())
         (
-          DynamoDbGameCache(dynamo, config.aws.dynamoGameTable),
-          DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable),
+          DynamoDbCacheProvider(dynamo, config.aws),
           DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable),
-          AwsSqsSender(sqs, config.aws.prefetchSqsUrl),
-          DynamoDbRequestCache(dynamo, config.aws.dynamoRequestTable)
+          AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
         )
 
       case CacheBackend.SQLite =>
         (
-          SqliteGameCache(config.cache.sqliteGameCachePath),
-          SqliteVectorStore(config.cache.sqliteVectorStorePath),
+          SqliteCacheProvider(config.cache),
           SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
-          NoOpSqsSender(),
-          NoOpRequestCache()
+          NoOpSqsSender()
         )
 
       case CacheBackend.Memory =>
         (
-          MemoryGameCache(),
-          SqliteVectorStore(config.cache.sqliteVectorStorePath),
+          MemoryCacheProvider(config.cache),
           SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
-          NoOpSqsSender(),
-          NoOpRequestCache()
+          NoOpSqsSender()
         )
 
-    val gameService =
-      GameService(bggClient, gameCache, vectorStore, requestCache, config.cache.vectorMinRatings, () => Instant.now())
-    ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, sqsSender, config)
+    val gameService = GameService(bggClient, caches, config.cache.vectorMinRatings, () => Instant.now())
+    ApiEndpoints(gameService, caches.gameCache, caches.vectorStore, prefetchStore, sqsSender, config)
 
   private def startServer(endpoints: ApiEndpoints, config: AppConfig): Unit =
     val serverOptions = NettySyncServerOptions.customiseInterceptors
-      .corsInterceptor(CORSInterceptor.customOrThrow[Identity](
-        CORSConfig.default.maxAge(scala.concurrent.duration.Duration(1, "day"))
-      ))
+      .corsInterceptor(
+        CORSInterceptor.customOrThrow[Identity](
+          CORSConfig.default.maxAge(scala.concurrent.duration.Duration(1, "day"))
+        )
+      )
       .defaultHandlers(
         msg =>
           if msg == "Not Found" then ValuedEndpointOutput(ErrorOutput.failOutput, bgg.domain.Fail.NotFound(msg))

--- a/src/main/scala/bgg/lambda/ApiLambdaHandler.scala
+++ b/src/main/scala/bgg/lambda/ApiLambdaHandler.scala
@@ -1,11 +1,10 @@
 package bgg.lambda
 
 import bgg.bggapi.{BggXmlClient, GameService}
-import bgg.cache.{DynamoDbGameCache, DynamoDbRequestCache}
+import bgg.cache.DynamoDbCacheProvider
 import bgg.config.AppConfig
 import bgg.prefetch.DynamoDbPrefetchStatusStore
 import bgg.routes.{ApiEndpoints, AwsSqsSender}
-import bgg.store.DynamoDbVectorStore
 import io.circe.generic.auto.*
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 import software.amazon.awssdk.regions.Region
@@ -43,12 +42,9 @@ object ApiLambdaHandler:
       .httpClient(UrlConnectionHttpClient.create())
       .build()
 
-    val gameCache = DynamoDbGameCache(dynamo, config.aws.dynamoGameTable)
-    val vectorStore = DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable)
-    val requestCache = DynamoDbRequestCache(dynamo, config.aws.dynamoRequestTable)
+    val caches = DynamoDbCacheProvider(dynamo, config.aws)
     val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
     val sqsSender = AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
-    val gameService =
-      GameService(bggClient, gameCache, vectorStore, requestCache, config.cache.vectorMinRatings, () => Instant.now())
+    val gameService = GameService(bggClient, caches, config.cache.vectorMinRatings, () => Instant.now())
 
-    ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, sqsSender, config)
+    ApiEndpoints(gameService, caches.gameCache, caches.vectorStore, prefetchStore, sqsSender, config)

--- a/src/main/scala/bgg/lambda/PrefetchWorker.scala
+++ b/src/main/scala/bgg/lambda/PrefetchWorker.scala
@@ -1,11 +1,10 @@
 package bgg.lambda
 
 import bgg.bggapi.{BggXmlClient, GameService}
-import bgg.cache.{DynamoDbGameCache, DynamoDbRequestCache, NoOpRequestCache, SqliteGameCache}
+import bgg.cache.{DynamoDbCacheProvider, SqliteCacheProvider}
 import bgg.config.{AppConfig, CacheBackend}
 import bgg.domain.{Fail, SourceType}
 import bgg.prefetch.{DynamoDbPrefetchStatusStore, PrefetchStatus, PrefetchStatusStore, SqlitePrefetchStatusStore}
-import bgg.store.{DynamoDbVectorStore, SqliteVectorStore}
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.typesafe.scalalogging.StrictLogging
@@ -24,21 +23,30 @@ object PrefetchMessage:
   given Decoder[PrefetchMessage] = Decoder.forProduct2("source_type", "source_id")(PrefetchMessage.apply)
 
 object PrefetchWorkerLogic:
-  def create(): PrefetchWorkerLogic =
-    val config = AppConfig.load()
+  def create(): PrefetchWorkerLogic = fromConfig(AppConfig.load())
+
+  private[lambda] def fromConfig(config: AppConfig): PrefetchWorkerLogic =
     val httpBackend = DefaultSyncBackend()
     val bggClient = BggXmlClient(config.bgg, httpBackend)
-    val dynamo = DynamoDbClient
-      .builder()
-      .region(Region.of(config.aws.region))
-      .httpClient(UrlConnectionHttpClient.create())
-      .build()
-    val gameCache = DynamoDbGameCache(dynamo, config.aws.dynamoGameTable)
-    val vectorStore = DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable)
-    val requestCache = DynamoDbRequestCache(dynamo, config.aws.dynamoRequestTable)
-    val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
-    val gameService =
-      GameService(bggClient, gameCache, vectorStore, requestCache, config.cache.vectorMinRatings, () => Instant.now())
+
+    val (caches, prefetchStore) = config.cache.backend match
+      case CacheBackend.DynamoDB =>
+        val dynamo = DynamoDbClient
+          .builder()
+          .region(Region.of(config.aws.region))
+          .httpClient(UrlConnectionHttpClient.create())
+          .build()
+        (
+          DynamoDbCacheProvider(dynamo, config.aws),
+          DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
+        )
+      case _ =>
+        (
+          SqliteCacheProvider(config.cache),
+          SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath)
+        )
+
+    val gameService = GameService(bggClient, caches, config.cache.vectorMinRatings, () => Instant.now())
     PrefetchWorkerLogic(gameService, prefetchStore)
 
 class PrefetchWorkerLogic(
@@ -77,6 +85,7 @@ class PrefetchWorkerLogic(
 
         result match
           case Right(_) =>
+            if sourceType == SourceType.Collection then gameService.fetchAndCachePlays(msg.sourceId)
             prefetchStore.set(sourceType, msg.sourceId, PrefetchStatus.Completed)
             logger.info(s"Prefetch complete for ${sourceType.toPathSegment}:${msg.sourceId}")
           case Left(Fail.BggUserNotFound(user)) =>
@@ -94,8 +103,7 @@ class PrefetchWorkerLogic(
 
 class PrefetchWorker extends RequestHandler[SQSEvent, Unit] with StrictLogging:
 
-  private lazy val config = AppConfig.load()
-  private lazy val logic = buildLogic()
+  private lazy val logic = PrefetchWorkerLogic.create()
 
   override def handleRequest(event: SQSEvent, context: Context): Unit =
     event.getRecords.asScala.foreach { record =>
@@ -105,46 +113,3 @@ class PrefetchWorker extends RequestHandler[SQSEvent, Unit] with StrictLogging:
         case Right(msg) =>
           logic.process(msg)
     }
-
-  private def buildLogic(): PrefetchWorkerLogic =
-    val httpBackend = DefaultSyncBackend()
-    val bggClient = BggXmlClient(config.bgg, httpBackend)
-
-    val (gameService, prefetchStore) = config.cache.backend match
-      case CacheBackend.DynamoDB =>
-        val dynamo = DynamoDbClient
-          .builder()
-          .region(Region.of(config.aws.region))
-          .httpClient(UrlConnectionHttpClient.create())
-          .build()
-        val gameCache = DynamoDbGameCache(dynamo, config.aws.dynamoGameTable)
-        val vectorStore = DynamoDbVectorStore(dynamo, config.aws.dynamoVectorTable)
-        val requestCache = DynamoDbRequestCache(dynamo, config.aws.dynamoRequestTable)
-        val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
-        val gameService =
-          GameService(
-            bggClient,
-            gameCache,
-            vectorStore,
-            requestCache,
-            config.cache.vectorMinRatings,
-            () => Instant.now()
-          )
-        (gameService, prefetchStore)
-
-      case _ =>
-        val gameCache = SqliteGameCache(config.cache.sqliteGameCachePath)
-        val vectorStore = SqliteVectorStore(config.cache.sqliteVectorStorePath)
-        val prefetchStore = SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath)
-        val gameService =
-          GameService(
-            bggClient,
-            gameCache,
-            vectorStore,
-            NoOpRequestCache(),
-            config.cache.vectorMinRatings,
-            () => Instant.now()
-          )
-        (gameService, prefetchStore)
-
-    PrefetchWorkerLogic(gameService, prefetchStore)

--- a/src/main/scala/bgg/routes/ApiEndpoints.scala
+++ b/src/main/scala/bgg/routes/ApiEndpoints.scala
@@ -3,7 +3,7 @@ package bgg.routes
 import bgg.bggapi.GameService
 import bgg.cache.GameCache
 import bgg.config.AppConfig
-import bgg.domain.*
+import bgg.domain.{Fail, GameData, GameId, PlayData, SourceType}
 import bgg.filter.GameFilter
 import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore}
 import bgg.recommendation.{RecommendationEngine, RecommendedGame}
@@ -116,6 +116,27 @@ class ApiEndpoints(
       gameService.resolveGameIds(List(GameId(id))).flatMap {
         case game :: _ => Right(FieldReduction(List(game), filters.fieldWhitelist).head)
         case Nil       => Left(Fail.NotFound(s"Game $id not found"))
+      }
+    }
+
+  // GET /plays/:username
+  val playsEndpoint = baseEndpoint.get
+    .in("plays" / path[String]("username"))
+    .in(headers)
+    .out(jsonBody[List[Json]])
+    .handle { (username, hdrs) =>
+      val filters = HeaderFilters.fromHeaders(hdrs)
+      gameService.resolvePlays(username).map { plays =>
+        val distinctIds = plays.map(_.gameId).distinct
+        val gameMap = gameCache.loadBatch(distinctIds).map(g => (g.id, g)).toMap
+
+        plays.map { p =>
+          val playJson = PlayData.encoder(p)
+          val gameJson = gameMap.get(p.gameId).map { game =>
+            FieldReduction(List(game), filters.fieldWhitelist).head
+          }
+          playJson.deepMerge(Json.obj("game" -> gameJson.getOrElse(Json.Null)))
+        }
       }
     }
 
@@ -257,18 +278,16 @@ class ApiEndpoints(
               Left(Fail.IncorrectInput(s"Proxy request failed: ${e.getClass.getName}: ${e.getMessage}"))
     }
 
+  private def resolveGamesAsMap(ids: List[GameId]): Map[GameId, GameData] =
+    gameService.resolveGameIds(ids) match
+      case Right(games) => games.map(g => (g.id, g)).toMap
+      case Left(_)      => gameCache.loadBatch(ids).map(g => (g.id, g)).toMap
+
   private def resolveInputGames(gameIds: List[GameId]): List[GameData] =
-    gameService.resolveGameIds(gameIds) match
-      case Right(games) => games
-      case Left(_) =>
-        gameIds.flatMap(id => gameCache.load(id).toList)
+    resolveGamesAsMap(gameIds).values.toList
 
   private def enrichRecommendations(recommendations: List[RecommendedGame]): List[RecommendedGameJson] =
-    val recIds = recommendations.map(_.gameId)
-    val gameMap: Map[GameId, GameData] = gameService.resolveGameIds(recIds) match
-      case Right(games) => games.map(g => (g.id, g)).toMap
-      case Left(_) =>
-        recIds.flatMap(id => gameCache.load(id).map(g => (id, g))).toMap
+    val gameMap = resolveGamesAsMap(recommendations.map(_.gameId))
 
     recommendations.map { r =>
       RecommendedGameJson(
@@ -300,6 +319,7 @@ class ApiEndpoints(
     geeklistEndpoint,
     hotEndpoint,
     gameEndpoint,
+    playsEndpoint,
     searchEndpoint,
     prefetchEndpoint,
     prefetchStatusEndpoint,

--- a/src/test/scala/bgg/SafeOpsSpec.scala
+++ b/src/test/scala/bgg/SafeOpsSpec.scala
@@ -1,0 +1,33 @@
+package bgg
+
+import com.typesafe.scalalogging.Logger
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.LoggerFactory
+
+class SafeOpsSpec extends AnyWordSpec with Matchers:
+
+  private given Logger = Logger(LoggerFactory.getLogger("test"))
+
+  "decodeJson" should:
+    "return Some on valid JSON" in:
+      SafeOps.decodeJson[Int]("42", "test int") shouldBe Some(42)
+
+    "return None on invalid JSON" in:
+      SafeOps.decodeJson[Int]("not-json", "test bad") shouldBe None
+
+  "tryAwsCall" should:
+    "return Some on success" in:
+      SafeOps.tryAwsCall("hello", "test") shouldBe Some("hello")
+
+    "return None on exception" in:
+      SafeOps.tryAwsCall(throw RuntimeException("boom"), "test err") shouldBe None
+
+  "trySqlCall" should:
+    "execute normally on success" in:
+      var ran = false
+      SafeOps.trySqlCall({ ran = true }, "test")
+      ran shouldBe true
+
+    "catch exception without propagating" in:
+      noException should be thrownBy SafeOps.trySqlCall(throw RuntimeException("boom"), "test err")

--- a/src/test/scala/bgg/TestFixtures.scala
+++ b/src/test/scala/bgg/TestFixtures.scala
@@ -1,0 +1,63 @@
+package bgg
+
+import bgg.bggapi.BggClient
+import bgg.config.*
+import bgg.domain.*
+
+object TestFixtures:
+
+  def testGame(id: Int, name: String): GameData = GameData(
+    id = GameId(id),
+    name = name,
+    yearPublished = Some(2020),
+    minPlayers = Some(2),
+    maxPlayers = Some(4),
+    minPlayingTime = Some(30),
+    maxPlayingTime = Some(60),
+    playingTime = Some(60),
+    ratingAverage = Some(7.5),
+    ratingAverageWeight = Some(2.5),
+    expansion = false,
+    mechanics = List("Hand Management"),
+    categories = List("Fantasy"),
+    playerSuggestions = Nil,
+    usersRated = Some(500)
+  )
+
+  def stubClient(
+      collectionResult: Either[Fail, List[GameId]] = Right(Nil),
+      geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
+      hotResult: Either[Fail, List[GameId]] = Right(Nil),
+      gamesResult: Either[Fail, List[GameData]] = Right(Nil),
+      playsResult: Either[Fail, List[PlayData]] = Right(Nil)
+  ): BggClient = new BggClient:
+    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
+    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
+    def fetchHotGames(): Either[Fail, List[GameId]] = hotResult
+    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
+    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+    def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = playsResult
+
+  val testConfig: AppConfig = AppConfig(
+    bgg = BggConfig(accessToken = "", timeoutSeconds = 10, retries = 3, retryDelaySeconds = 1),
+    cache = CacheConfig(
+      backend = CacheBackend.Memory,
+      requestCacheTtlSeconds = 60,
+      gameCacheTtlSeconds = 3600,
+      vectorMinRatings = 50,
+      sqliteRequestCachePath = "",
+      sqliteGameCachePath = "",
+      sqliteVectorStorePath = "",
+      sqlitePrefetchStatusPath = ""
+    ),
+    aws = AwsConfig(
+      region = "us-east-1",
+      dynamoRequestTable = "",
+      dynamoGameTable = "",
+      dynamoVectorTable = "",
+      dynamoPrefetchTable = "",
+      dynamoPlaysTable = "",
+      prefetchSqsUrl = ""
+    ),
+    server = ServerConfig(host = "0.0.0.0", port = 8080, allowedOrigins = List("*"))
+  )

--- a/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
+++ b/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
@@ -214,6 +214,28 @@ class BggXmlClientSpec extends AnyWordSpec with Matchers:
 
       result shouldBe Right(Nil)
 
+  "fetchHotGames" should:
+    "parse game IDs from hot games XML" in:
+      val hotXml =
+        """<items>
+          |  <item id="174430" rank="1"/>
+          |  <item id="167791" rank="2"/>
+          |</items>""".stripMargin
+      val backend = stubBackend(body = hotXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchHotGames()
+
+      result shouldBe Right(List(GameId(174430), GameId(167791)))
+
+    "return empty list on empty hot games response" in:
+      val backend = stubBackend(body = "<items></items>")
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchHotGames()
+
+      result shouldBe Right(Nil)
+
   "searchGames" should:
     "return empty list for queries shorter than 3 characters" in:
       val backend = stubBackend()
@@ -259,6 +281,57 @@ class BggXmlClientSpec extends AnyWordSpec with Matchers:
       client.searchGames("game")
 
       fetchCount shouldBe 20
+
+  "fetchPlays" should:
+    "parse plays from XML response" in:
+      val playsXml =
+        """<plays total="2" page="1">
+          |  <play id="100" date="2024-01-01" quantity="1" length="45">
+          |    <item name="Pandemic" objecttype="thing" objectid="30549"/>
+          |    <players>
+          |      <player username="alice" name="Alice" score="10" win="1"/>
+          |    </players>
+          |  </play>
+          |  <play id="101" date="2024-01-02" quantity="2" length="60">
+          |    <item name="Catan" objecttype="thing" objectid="13"/>
+          |  </play>
+          |</plays>""".stripMargin
+      val backend = stubBackend(body = playsXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchPlays("testuser", 1)
+
+      result.isRight shouldBe true
+      val plays = result.toOption.get
+      plays should have size 2
+      plays.head.gameId shouldBe GameId(30549)
+      plays.head.players should have size 1
+
+    "use correct URL with username and page params" in:
+      var capturedUrl = ""
+      val backend = SyncBackendStub
+        .whenRequestMatchesPartial { request =>
+          capturedUrl = request.uri.toString
+          ResponseStub.adjust(
+            """<plays total="1" page="1"><play id="1" date="2024-01-01" quantity="1" length="0"><item name="X" objecttype="thing" objectid="1"/></play></plays>""",
+            StatusCode.Ok
+          )
+        }
+      val client = BggXmlClient(defaultConfig, backend)
+
+      client.fetchPlays("myuser", 3)
+
+      capturedUrl should include("xmlapi2/plays")
+      capturedUrl should include("username=myuser")
+      capturedUrl should include("page=3")
+
+    "return empty list when total is 0" in:
+      val backend = stubBackend(body = """<plays total="0" page="1"></plays>""")
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchPlays("nobody", 1)
+
+      result shouldBe Right(Nil)
 
   "retry logic" should:
     "retry on 202 responses" in:

--- a/src/test/scala/bgg/bggapi/GameServiceSpec.scala
+++ b/src/test/scala/bgg/bggapi/GameServiceSpec.scala
@@ -1,0 +1,252 @@
+package bgg.bggapi
+
+import bgg.TestFixtures.testGame
+import bgg.cache.{MemoryGameCache, PlaysCache, RequestCache, TestCacheProvider}
+import bgg.domain.*
+import bgg.store.SqliteVectorStore
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Files, Paths}
+import java.time.Instant
+import scala.collection.mutable
+
+class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
+
+  private val vectorDb = "test_game_service_vectors.sqlite"
+  private var vectorStore: SqliteVectorStore = _
+  private var gameCache: MemoryGameCache = _
+
+  override def beforeEach(): Unit =
+    Files.deleteIfExists(Paths.get(vectorDb)): Unit
+    vectorStore = SqliteVectorStore(vectorDb)
+    gameCache = MemoryGameCache()
+
+  override def afterEach(): Unit =
+    vectorStore.close()
+    Files.deleteIfExists(Paths.get(vectorDb)): Unit
+
+  private class MemoryPlaysCache extends PlaysCache:
+    val store: mutable.Map[String, List[PlayData]] = mutable.Map.empty
+    def save(username: String, plays: List[PlayData]): Unit = store(username) = plays
+    def load(username: String): Option[List[PlayData]] = store.get(username)
+
+  private class MemoryRequestCache extends RequestCache:
+    private val store: mutable.Map[String, String] = mutable.Map.empty
+    def load[T: io.circe.Decoder](key: String): Option[T] =
+      store.get(key).flatMap(json => io.circe.parser.decode[T](json).toOption)
+    def save[T: io.circe.Encoder](key: String, value: T, ttlSeconds: Long, now: Instant): Unit =
+      store(key) = io.circe.syntax.EncoderOps(value).asJson.noSpaces
+
+  private val testPlay = PlayData(
+    playId = 1,
+    gameId = GameId(13),
+    gameName = "Catan",
+    date = "2024-03-15",
+    quantity = 1,
+    length = 60,
+    players = List(PlayPlayer("alice", "Alice", Some("10"), win = true))
+  )
+
+  private def stubClient(
+      playsPage1: Either[Fail, List[PlayData]] = Right(Nil)
+  ): BggClient = new BggClient:
+    def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+    def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
+    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+    def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] =
+      if page == 1 then playsPage1 else Right(Nil)
+
+  "resolvePlays" should:
+    "serve from cache when plays are cached" in:
+      val playsCache = MemoryPlaysCache()
+      playsCache.save("alice", List(testPlay))
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val service = GameService(stubClient(), caches, 50, () => Instant.now())
+
+      val result = service.resolvePlays("alice")
+
+      result shouldBe Right(List(testPlay))
+
+    "fetch from BGG and cache when no cached plays" in:
+      val playsCache = MemoryPlaysCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val client = stubClient(playsPage1 = Right(List(testPlay)))
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolvePlays("bob")
+
+      result shouldBe Right(List(testPlay))
+      playsCache.store.get("bob") shouldBe Some(List(testPlay))
+
+    "return error when BGG fetch fails and no cache" in:
+      val playsCache = MemoryPlaysCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val client = stubClient(playsPage1 = Left(Fail.BggUserNotFound("ghost")))
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolvePlays("ghost")
+
+      result shouldBe Left(Fail.BggUserNotFound("ghost"))
+
+    "paginate until empty page" in:
+      var pageRequests = List.empty[Int]
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] =
+          pageRequests = pageRequests :+ page
+          if page <= 2 then Right(List(testPlay.copy(playId = page)))
+          else Right(Nil)
+
+      val playsCache = MemoryPlaysCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolvePlays("paginated")
+
+      result.isRight shouldBe true
+      result.toOption.get should have size 2
+      pageRequests shouldBe List(1, 2, 3)
+
+    "stop pagination on error after first page" in:
+      var pageRequests = List.empty[Int]
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] =
+          pageRequests = pageRequests :+ page
+          if page == 1 then Right(List(testPlay))
+          else Left(Fail.BggRateLimited("rate limited"))
+
+      val playsCache = MemoryPlaysCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolvePlays("ratelimited")
+
+      result shouldBe Right(List(testPlay))
+
+  "fetchAndCachePlays" should:
+    "fetch and save plays to cache" in:
+      val playsCache = MemoryPlaysCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val client = stubClient(playsPage1 = Right(List(testPlay)))
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.fetchAndCachePlays("dave")
+
+      playsCache.store.get("dave") shouldBe Some(List(testPlay))
+
+    "not crash when fetch fails" in:
+      val playsCache = MemoryPlaysCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val client = stubClient(playsPage1 = Left(Fail.BggUserNotFound("ghost")))
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      noException should be thrownBy service.fetchAndCachePlays("ghost")
+      playsCache.store.get("ghost") shouldBe None
+
+  "resolveHotGames" should:
+    "cache result in request cache and serve from cache on second call" in:
+      var fetchCount = 0
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] =
+          fetchCount += 1
+          Right(List(GameId(1)))
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(testGame(1, "Catan")))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val reqCache = MemoryRequestCache()
+      val caches = TestCacheProvider(gameCache, vectorStore, requestCache = reqCache)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result1 = service.resolveHotGames()
+      val result2 = service.resolveHotGames()
+
+      result1.isRight shouldBe true
+      result2.isRight shouldBe true
+      fetchCount shouldBe 1
+
+  "resolveGameIds (vectorize paths)" should:
+    "vectorize a mature game with enough ratings" in:
+      val matureGame = testGame(1, "Old Classic").copy(yearPublished = Some(2010), usersRated = Some(1000))
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(matureGame))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.resolveGameIds(List(GameId(1)))
+
+      vectorStore.load(GameId(1)) should be(defined)
+
+    "not vectorize a mature game with too few ratings" in:
+      val lowRated = testGame(2, "Obscure").copy(yearPublished = Some(2010), usersRated = Some(5))
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(lowRated))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.resolveGameIds(List(GameId(2)))
+
+      vectorStore.load(GameId(2)) shouldBe None
+
+    "vectorize a new game with minimum ratings" in:
+      val currentYear = java.time.Year.now(java.time.ZoneOffset.UTC).getValue
+      val newGame = testGame(3, "Brand New").copy(yearPublished = Some(currentYear), usersRated = Some(15))
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(newGame))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.resolveGameIds(List(GameId(3)))
+
+      vectorStore.load(GameId(3)) should be(defined)
+
+    "not vectorize a new game with too few ratings" in:
+      val currentYear = java.time.Year.now(java.time.ZoneOffset.UTC).getValue
+      val tooNew = testGame(4, "Too New").copy(yearPublished = Some(currentYear), usersRated = Some(3))
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(tooNew))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.resolveGameIds(List(GameId(4)))
+
+      vectorStore.load(GameId(4)) shouldBe None

--- a/src/test/scala/bgg/bggapi/XmlParserSpec.scala
+++ b/src/test/scala/bgg/bggapi/XmlParserSpec.scala
@@ -1,10 +1,118 @@
 package bgg.bggapi
 
-import bgg.domain.{GameData, GameId, PlayerSuggestion}
+import bgg.domain.{GameId, PlayerSuggestion}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class XmlParserSpec extends AnyWordSpec with Matchers:
+
+  "parsePlays" should:
+    "parse a complete play with players" in:
+      val xml =
+        <plays total="1" page="1">
+          <play id="12345" date="2024-03-15" quantity="1" length="90">
+            <item name="Catan" objecttype="thing" objectid="13">
+            </item>
+            <players>
+              <player username="alice" name="Alice" score="10" win="1"/>
+              <player username="bob" name="Bob" score="7" win="0"/>
+            </players>
+          </play>
+        </plays>
+
+      val result = XmlParser.parsePlays(xml)
+      result should have size 1
+
+      val play = result.head
+      play.playId shouldBe 12345
+      play.gameId shouldBe GameId(13)
+      play.gameName shouldBe "Catan"
+      play.date shouldBe "2024-03-15"
+      play.quantity shouldBe 1
+      play.length shouldBe 90
+      play.players should have size 2
+      play.players.head.username shouldBe "alice"
+      play.players.head.name shouldBe "Alice"
+      play.players.head.score shouldBe Some("10")
+      play.players.head.win shouldBe true
+      play.players(1).win shouldBe false
+
+    "parse multiple plays" in:
+      val xml =
+        <plays total="2" page="1">
+          <play id="100" date="2024-01-01" quantity="2" length="45">
+            <item name="Pandemic" objecttype="thing" objectid="30549"/>
+          </play>
+          <play id="101" date="2024-01-02" quantity="1" length="60">
+            <item name="Catan" objecttype="thing" objectid="13"/>
+          </play>
+        </plays>
+
+      val result = XmlParser.parsePlays(xml)
+      result should have size 2
+      result.map(_.playId) shouldBe List(100, 101)
+
+    "skip plays without a play id" in:
+      val xml =
+        <plays total="1" page="1">
+          <play date="2024-01-01" quantity="1" length="30">
+            <item name="Chess" objecttype="thing" objectid="171"/>
+          </play>
+        </plays>
+
+      XmlParser.parsePlays(xml) shouldBe empty
+
+    "skip plays without a game objectid" in:
+      val xml =
+        <plays total="1" page="1">
+          <play id="200" date="2024-01-01" quantity="1" length="30">
+            <item name="Unknown" objecttype="thing"/>
+          </play>
+        </plays>
+
+      XmlParser.parsePlays(xml) shouldBe empty
+
+    "default quantity to 1 and length to 0 when missing" in:
+      val xml =
+        <plays total="1" page="1">
+          <play id="300" date="2024-06-01">
+            <item name="Go" objecttype="thing" objectid="188"/>
+          </play>
+        </plays>
+
+      val result = XmlParser.parsePlays(xml)
+      result should have size 1
+      result.head.quantity shouldBe 1
+      result.head.length shouldBe 0
+
+    "handle plays with no players element" in:
+      val xml =
+        <plays total="1" page="1">
+          <play id="400" date="2024-02-01" quantity="1" length="30">
+            <item name="Solo" objecttype="thing" objectid="999"/>
+          </play>
+        </plays>
+
+      val result = XmlParser.parsePlays(xml)
+      result.head.players shouldBe empty
+
+    "handle player with empty score" in:
+      val xml =
+        <plays total="1" page="1">
+          <play id="500" date="2024-03-01" quantity="1" length="45">
+            <item name="Catan" objecttype="thing" objectid="13"/>
+            <players>
+              <player username="carl" name="Carl" score="" win="0"/>
+            </players>
+          </play>
+        </plays>
+
+      val result = XmlParser.parsePlays(xml)
+      result.head.players.head.score shouldBe None
+
+    "return empty list when no plays present" in:
+      val xml = <plays total="0" page="1"></plays>
+      XmlParser.parsePlays(xml) shouldBe empty
 
   "parseThings" should:
     "parse a single complete item" in:

--- a/src/test/scala/bgg/cache/TestCacheProvider.scala
+++ b/src/test/scala/bgg/cache/TestCacheProvider.scala
@@ -1,0 +1,10 @@
+package bgg.cache
+
+import bgg.store.VectorStore
+
+class TestCacheProvider(
+    val gameCache: GameCache,
+    val vectorStore: VectorStore,
+    val requestCache: RequestCache = NoOpRequestCache(),
+    val playsCache: PlaysCache = NoOpPlaysCache()
+) extends CacheProvider

--- a/src/test/scala/bgg/domain/GameDataDecoderSpec.scala
+++ b/src/test/scala/bgg/domain/GameDataDecoderSpec.scala
@@ -118,6 +118,36 @@ class GameDataDecoderSpec extends AnyWordSpec with Matchers:
       game.playerSuggestions shouldBe empty
     }
 
+    "encode PlayData with all fields" in {
+      val play = PlayData(
+        playId = 123,
+        gameId = GameId(456),
+        gameName = "Test Game",
+        date = "2024-06-01",
+        quantity = 2,
+        length = 90,
+        players = List(
+          PlayPlayer("user1", "User One", Some("15"), win = true),
+          PlayPlayer("user2", "User Two", None, win = false)
+        )
+      )
+
+      val json = PlayData.encoder(play)
+      json.hcursor.get[Int]("play_id").toOption shouldBe Some(123)
+      json.hcursor.get[Int]("game_id").toOption shouldBe Some(456)
+      json.hcursor.get[String]("game_name").toOption shouldBe Some("Test Game")
+      json.hcursor.get[String]("date").toOption shouldBe Some("2024-06-01")
+      json.hcursor.get[Int]("quantity").toOption shouldBe Some(2)
+      json.hcursor.get[Int]("length").toOption shouldBe Some(90)
+
+      val players = json.hcursor.downField("players").as[List[io.circe.Json]].toOption.get
+      players should have size 2
+      players.head.hcursor.get[String]("username").toOption shouldBe Some("user1")
+      players.head.hcursor.get[Boolean]("win").toOption shouldBe Some(true)
+      players.head.hcursor.get[String]("score").toOption shouldBe Some("15")
+      players(1).hcursor.downField("score").focus.get.isNull shouldBe true
+    }
+
     "round-trip through encode/decode" in {
       val original = GameData(
         id = GameId(42),

--- a/src/test/scala/bgg/lambda/ApiLambdaHandlerSpec.scala
+++ b/src/test/scala/bgg/lambda/ApiLambdaHandlerSpec.scala
@@ -1,8 +1,8 @@
 package bgg.lambda
 
+import bgg.TestFixtures.{stubClient, testConfig, testGame}
 import bgg.bggapi.{BggClient, GameService}
-import bgg.cache.{MemoryGameCache, NoOpRequestCache}
-import bgg.config.*
+import bgg.cache.{MemoryGameCache, TestCacheProvider}
 import bgg.domain.*
 import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
 import bgg.routes.{ApiEndpoints, NoOpSqsSender}
@@ -41,42 +41,8 @@ class ApiLambdaHandlerSpec extends AnyWordSpec with Matchers with BeforeAndAfter
     Files.deleteIfExists(Paths.get(prefetchDb)): Unit
     Files.deleteIfExists(Paths.get(vectorDb)): Unit
 
-  private val testConfig = AppConfig(
-    bgg = BggConfig(accessToken = "", timeoutSeconds = 10, retries = 3, retryDelaySeconds = 1),
-    cache = CacheConfig(
-      backend = CacheBackend.Memory,
-      requestCacheTtlSeconds = 60,
-      gameCacheTtlSeconds = 3600,
-      vectorMinRatings = 50,
-      sqliteRequestCachePath = "",
-      sqliteGameCachePath = "",
-      sqliteVectorStorePath = "",
-      sqlitePrefetchStatusPath = ""
-    ),
-    aws = AwsConfig(
-      region = "us-east-1",
-      dynamoRequestTable = "",
-      dynamoGameTable = "",
-      dynamoVectorTable = "",
-      dynamoPrefetchTable = "",
-      prefetchSqsUrl = ""
-    ),
-    server = ServerConfig(host = "0.0.0.0", port = 8080, allowedOrigins = List("*"))
-  )
-
-  private def stubClient(
-      collectionResult: Either[Fail, List[GameId]] = Right(Nil),
-      geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
-      gamesResult: Either[Fail, List[GameData]] = Right(Nil)
-  ): BggClient = new BggClient:
-    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
-    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
-    def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
-    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
-    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
-
   private def makeHandler(bggClient: BggClient): SyncLambdaHandler[AwsRequestV1] =
-    val gameService = GameService(bggClient, gameCache, vectorStore, NoOpRequestCache(), 50, () => Instant.now())
+    val gameService = GameService(bggClient, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
     val endpoints = ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig)
     SyncLambdaHandler(endpoints.all, AwsSyncServerOptions.default)
 
@@ -136,24 +102,6 @@ class ApiLambdaHandlerSpec extends AnyWordSpec with Matchers with BeforeAndAfter
        |  "body": ${Json.fromString(body).noSpaces},
        |  "isBase64Encoded": false
        |}""".stripMargin
-
-  private def testGame(id: Int, name: String): GameData = GameData(
-    id = GameId(id),
-    name = name,
-    yearPublished = Some(2020),
-    minPlayers = Some(2),
-    maxPlayers = Some(4),
-    minPlayingTime = Some(30),
-    maxPlayingTime = Some(60),
-    playingTime = Some(60),
-    ratingAverage = Some(7.5),
-    ratingAverageWeight = Some(2.5),
-    expansion = false,
-    mechanics = List("Hand Management"),
-    categories = List("Fantasy"),
-    playerSuggestions = Nil,
-    usersRated = Some(500)
-  )
 
   "SyncLambdaHandler with API Gateway V1 events" should:
     "route GET /health and return 200" in:

--- a/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
@@ -1,7 +1,8 @@
 package bgg.lambda
 
+import bgg.TestFixtures.{stubClient, testGame}
 import bgg.bggapi.{BggClient, GameService}
-import bgg.cache.{MemoryGameCache, NoOpRequestCache}
+import bgg.cache.{MemoryGameCache, TestCacheProvider}
 import bgg.domain.*
 import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
 import bgg.store.SqliteVectorStore
@@ -33,37 +34,8 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
     Files.deleteIfExists(Paths.get(prefetchDb)): Unit
     Files.deleteIfExists(Paths.get(vectorDb)): Unit
 
-  private def testGame(id: Int, name: String): GameData = GameData(
-    id = GameId(id),
-    name = name,
-    yearPublished = Some(2020),
-    minPlayers = Some(2),
-    maxPlayers = Some(4),
-    minPlayingTime = Some(30),
-    maxPlayingTime = Some(60),
-    playingTime = Some(60),
-    ratingAverage = Some(7.5),
-    ratingAverageWeight = Some(2.5),
-    expansion = false,
-    mechanics = List("Hand Management"),
-    categories = List("Fantasy"),
-    playerSuggestions = Nil,
-    usersRated = Some(500)
-  )
-
-  private def stubClient(
-      collectionResult: Either[Fail, List[GameId]] = Right(Nil),
-      geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
-      gamesResult: Either[Fail, List[GameData]] = Right(Nil)
-  ): BggClient = new BggClient:
-    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
-    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
-    def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
-    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
-    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
-
   private def makeLogic(client: BggClient): PrefetchWorkerLogic =
-    val gameService = GameService(client, gameCache, vectorStore, NoOpRequestCache(), 50, () => Instant.now())
+    val gameService = GameService(client, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
     PrefetchWorkerLogic(gameService, prefetchStore)
 
   "PrefetchWorkerLogic" should:
@@ -134,6 +106,7 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
         def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
 
       val logic = makeLogic(client)
       logic.process(PrefetchMessage("collection", "testuser"))
@@ -145,6 +118,62 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
       val logic = makeLogic(client)
 
       noException should be thrownBy logic.process(PrefetchMessage("invalid_type", "testuser"))
+
+    "set status to Completed on successful hot games prefetch" in:
+      val games = List(testGame(1, "Catan"))
+      val hotClient = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(List(GameId(1)))
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(games)
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+      val logic = makeLogic(hotClient)
+
+      logic.process(PrefetchMessage("hot", "trending"))
+
+      val record = prefetchStore.get(SourceType.Hot, "trending")
+      record.map(_.status) shouldBe Some(PrefetchStatus.Completed)
+
+    "handleSqsEvent should process valid SQS records" in:
+      val games = List(testGame(1, "Catan"))
+      val client = stubClient(
+        collectionResult = Right(List(GameId(1))),
+        gamesResult = Right(games)
+      )
+      val logic = makeLogic(client)
+
+      val event = """{"Records":[{"body":"{\"source_type\":\"collection\",\"source_id\":\"testuser\"}"}]}"""
+      val result = logic.handleSqsEvent(event)
+
+      result shouldBe """{"statusCode":200}"""
+      prefetchStore.get(SourceType.Collection, "testuser").map(_.status) shouldBe Some(PrefetchStatus.Completed)
+
+    "handleSqsEvent should handle invalid JSON gracefully" in:
+      val client = stubClient()
+      val logic = makeLogic(client)
+
+      val result = logic.handleSqsEvent("not json at all")
+
+      result shouldBe """{"statusCode":200}"""
+
+    "handleSqsEvent should handle invalid message body gracefully" in:
+      val client = stubClient()
+      val logic = makeLogic(client)
+
+      val event = """{"Records":[{"body":"not a valid message"}]}"""
+      val result = logic.handleSqsEvent(event)
+
+      result shouldBe """{"statusCode":200}"""
+
+    "handleSqsEvent should handle record with missing body field" in:
+      val client = stubClient()
+      val logic = makeLogic(client)
+
+      val event = """{"Records":[{"notBody":"something"}]}"""
+      val result = logic.handleSqsEvent(event)
+
+      result shouldBe """{"statusCode":200}"""
 
     "cache fetched games during prefetch" in:
       val games = List(testGame(1, "Catan"))

--- a/src/test/scala/bgg/lambda/PrefetchWorkerSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerSpec.scala
@@ -1,7 +1,8 @@
 package bgg.lambda
 
+import bgg.TestFixtures.{stubClient, testGame}
 import bgg.bggapi.{BggClient, GameService}
-import bgg.cache.{MemoryGameCache, NoOpRequestCache}
+import bgg.cache.{MemoryGameCache, TestCacheProvider}
 import bgg.domain.*
 import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
 import bgg.store.SqliteVectorStore
@@ -33,7 +34,7 @@ class PrefetchWorkerSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
 
   private def makeWorker(bggClient: BggClient): PrefetchWorkerLogic =
     val gameCache = MemoryGameCache()
-    val gameService = GameService(bggClient, gameCache, vectorStore, NoOpRequestCache(), 50, () => Instant.now())
+    val gameService = GameService(bggClient, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
     PrefetchWorkerLogic(gameService, prefetchStore)
 
   "PrefetchWorkerLogic" should:
@@ -102,6 +103,7 @@ class PrefetchWorkerSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
 
       val worker = makeWorker(client)
       worker.process(PrefetchMessage("collection", "observer"))
@@ -112,32 +114,3 @@ class PrefetchWorkerSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
       val client = stubClient()
       val worker = makeWorker(client)
       noException should be thrownBy worker.process(PrefetchMessage("invalid_type", "x"))
-
-  private def testGame(id: Int, name: String): GameData = GameData(
-    id = GameId(id),
-    name = name,
-    yearPublished = Some(2020),
-    minPlayers = Some(2),
-    maxPlayers = Some(4),
-    minPlayingTime = Some(30),
-    maxPlayingTime = Some(60),
-    playingTime = Some(60),
-    ratingAverage = Some(7.5),
-    ratingAverageWeight = Some(2.5),
-    expansion = false,
-    mechanics = List("Hand Management"),
-    categories = List("Fantasy"),
-    playerSuggestions = Nil,
-    usersRated = Some(500)
-  )
-
-  private def stubClient(
-      collectionResult: Either[Fail, List[GameId]] = Right(Nil),
-      geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
-      gamesResult: Either[Fail, List[GameData]] = Right(Nil)
-  ): BggClient = new BggClient:
-    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
-    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
-    def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
-    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
-    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)

--- a/src/test/scala/bgg/recommendation/RecommendationEngineSpec.scala
+++ b/src/test/scala/bgg/recommendation/RecommendationEngineSpec.scala
@@ -1,5 +1,6 @@
 package bgg.recommendation
 
+import bgg.TestFixtures.testGame
 import bgg.cache.MemoryGameCache
 import bgg.domain.*
 import bgg.store.{SqliteVectorStore, StoredVector}
@@ -26,27 +27,9 @@ class RecommendationEngineSpec extends AnyWordSpec with Matchers with BeforeAndA
     vectorStore.close()
     Files.deleteIfExists(Paths.get(testDb)): Unit
 
-  private def game(id: Int, name: String): GameData = GameData(
-    id = GameId(id),
-    name = name,
-    yearPublished = Some(2020),
-    minPlayers = Some(2),
-    maxPlayers = Some(4),
-    minPlayingTime = Some(30),
-    maxPlayingTime = Some(60),
-    playingTime = Some(60),
-    ratingAverage = Some(7.5),
-    ratingAverageWeight = Some(2.5),
-    expansion = false,
-    mechanics = List("Hand Management"),
-    categories = List("Fantasy"),
-    playerSuggestions = Nil,
-    usersRated = Some(500)
-  )
-
   "RecommendationEngine" should:
     "return empty list when vector store is empty" in:
-      val taste = VectorMath.buildTasteVector(List(game(1, "Input")))
+      val taste = VectorMath.buildTasteVector(List(testGame(1, "Input")))
       val result = RecommendationEngine.recommend(
         taste,
         vectorStore,
@@ -58,9 +41,9 @@ class RecommendationEngineSpec extends AnyWordSpec with Matchers with BeforeAndA
       result shouldBe empty
 
     "return top N similar games" in:
-      val g1 = game(1, "Catan")
-      val g2 = game(2, "Pandemic")
-      val g3 = game(3, "Chess")
+      val g1 = testGame(1, "Catan")
+      val g2 = testGame(2, "Pandemic")
+      val g3 = testGame(3, "Chess")
       vectorStore.save(StoredVector(g1.id, g1.name, VectorMath.generateGameVector(g1), Instant.now()))
       vectorStore.save(StoredVector(g2.id, g2.name, VectorMath.generateGameVector(g2), Instant.now()))
       vectorStore.save(StoredVector(g3.id, g3.name, VectorMath.generateGameVector(g3), Instant.now()))
@@ -79,7 +62,7 @@ class RecommendationEngineSpec extends AnyWordSpec with Matchers with BeforeAndA
       result.map(_.gameId.value).toSet should not contain 1
 
     "exclude specified game IDs" in:
-      val g = game(1, "Excluded")
+      val g = testGame(1, "Excluded")
       vectorStore.save(StoredVector(g.id, g.name, VectorMath.generateGameVector(g), Instant.now()))
 
       val taste = VectorMath.buildTasteVector(List(g))
@@ -94,9 +77,33 @@ class RecommendationEngineSpec extends AnyWordSpec with Matchers with BeforeAndA
 
       result.map(_.gameId.value) should not contain 1
 
+    "apply filters and skip games not in cache" in:
+      val g1 = testGame(1, "Catan").copy(minPlayers = Some(2), maxPlayers = Some(4))
+      val g2 = testGame(2, "Solo Game").copy(minPlayers = Some(1), maxPlayers = Some(1))
+      val g3 = testGame(3, "Party Game").copy(minPlayers = Some(4), maxPlayers = Some(10))
+      gameCache.save(g1, Instant.now())
+      gameCache.save(g2, Instant.now())
+      vectorStore.save(StoredVector(g1.id, g1.name, VectorMath.generateGameVector(g1), Instant.now()))
+      vectorStore.save(StoredVector(g2.id, g2.name, VectorMath.generateGameVector(g2), Instant.now()))
+      vectorStore.save(StoredVector(g3.id, g3.name, VectorMath.generateGameVector(g3), Instant.now()))
+
+      val taste = VectorMath.buildTasteVector(List(g1))
+      val filters = GameFilters.default.copy(playerCount = Some(2))
+      val result = RecommendationEngine.recommend(
+        taste,
+        vectorStore,
+        gameCache,
+        limit = 5,
+        excludeIds = Set.empty,
+        filters = filters
+      )
+
+      result.map(_.gameId) should not contain GameId(2)
+      result.map(_.gameId) should not contain GameId(3)
+
     "sort results by similarity score descending" in:
-      val g1 = game(1, "Game 1")
-      val g2 = game(2, "Game 2")
+      val g1 = testGame(1, "Game 1")
+      val g2 = testGame(2, "Game 2")
       vectorStore.save(StoredVector(g1.id, g1.name, VectorMath.generateGameVector(g1), Instant.now()))
       vectorStore.save(
         StoredVector(

--- a/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
+++ b/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
@@ -1,8 +1,8 @@
 package bgg.routes
 
+import bgg.TestFixtures.{stubClient, testConfig, testGame}
 import bgg.bggapi.{BggClient, GameService}
-import bgg.cache.{MemoryGameCache, NoOpRequestCache}
-import bgg.config.*
+import bgg.cache.{MemoryGameCache, TestCacheProvider}
 import bgg.domain.*
 import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
 import bgg.store.{SqliteVectorStore, StoredVector}
@@ -46,66 +46,13 @@ class ApiEndpointsSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach
     Files.deleteIfExists(Paths.get(vectorDb)): Unit
 
   private def makeEndpoints(bggClient: BggClient): ApiEndpoints =
-    val gameService = GameService(bggClient, gameCache, vectorStore, NoOpRequestCache(), 50, () => Instant.now())
+    val gameService = GameService(bggClient, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
     ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig)
 
   private def makeBackend(endpoints: ApiEndpoints): Backend[Identity] =
     TapirStubInterpreter(BackendStub(IdentityMonad))
       .whenServerEndpointsRunLogic(endpoints.all)
       .backend()
-
-  private val testConfig = AppConfig(
-    bgg = BggConfig(accessToken = "", timeoutSeconds = 10, retries = 3, retryDelaySeconds = 1),
-    cache = CacheConfig(
-      backend = CacheBackend.Memory,
-      requestCacheTtlSeconds = 60,
-      gameCacheTtlSeconds = 3600,
-      vectorMinRatings = 50,
-      sqliteRequestCachePath = "",
-      sqliteGameCachePath = "",
-      sqliteVectorStorePath = "",
-      sqlitePrefetchStatusPath = ""
-    ),
-    aws = AwsConfig(
-      region = "us-east-1",
-      dynamoRequestTable = "",
-      dynamoGameTable = "",
-      dynamoVectorTable = "",
-      dynamoPrefetchTable = "",
-      prefetchSqsUrl = ""
-    ),
-    server = ServerConfig(host = "0.0.0.0", port = 8080, allowedOrigins = List("*"))
-  )
-
-  private def testGame(id: Int, name: String): GameData = GameData(
-    id = GameId(id),
-    name = name,
-    yearPublished = Some(2020),
-    minPlayers = Some(2),
-    maxPlayers = Some(4),
-    minPlayingTime = Some(30),
-    maxPlayingTime = Some(60),
-    playingTime = Some(60),
-    ratingAverage = Some(7.5),
-    ratingAverageWeight = Some(2.5),
-    expansion = false,
-    mechanics = List("Hand Management"),
-    categories = List("Fantasy"),
-    playerSuggestions = Nil,
-    usersRated = Some(500)
-  )
-
-  private def stubClient(
-      collectionResult: Either[Fail, List[GameId]] = Right(Nil),
-      geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
-      hotResult: Either[Fail, List[GameId]] = Right(Nil),
-      gamesResult: Either[Fail, List[GameData]] = Right(Nil)
-  ): BggClient = new BggClient:
-    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
-    def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
-    def fetchHotGames(): Either[Fail, List[GameId]] = hotResult
-    def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
-    def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
 
   "GET /health" should:
     "return 200 with status ok" in:
@@ -543,12 +490,9 @@ class ApiEndpointsSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach
       json.hcursor.get[Int]("total_dimensions").toOption shouldBe Some(155)
 
   "GET /cors-proxy/:b64url" should:
-    def encodeUrl(url: String): String =
-      "_" + Base64.getUrlEncoder.withoutPadding.encodeToString(url.getBytes("UTF-8"))
-
     def makeProxyEndpoints(): ApiEndpoints =
       val client = stubClient()
-      val gameService = GameService(client, gameCache, vectorStore, NoOpRequestCache(), 50, () => Instant.now())
+      val gameService = GameService(client, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
       ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig)
 
     "return 400 for invalid base64 input" in:


### PR DESCRIPTION
Add /plays/:username endpoint with BGG plays fetching and game enrichment. Add DynamoDB BatchGetItem for game cache with UnprocessedKeys retry. Add scoverage with 90% statement/branch minimums (currently 92%/90%). Consolidate test fixtures and deduplicate game resolution patterns.

Review fixes: handle DynamoDB UnprocessedKeys with retry loop, guard against null 'data' attributes, fix fetchPlays treating total=0 as user-not-found, sort all-cached path in resolveGameIds, replace O(n^2) list append with prepend-then-flatten, add MaxPlayPages safety valve, use cache-only game lookup in plays endpoint to avoid request-path BGG fetches.