### PR TITLE
fix: add DynamoDB plays table and 24h TTL cache freshness

### DIFF
--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -59,6 +59,7 @@ Globals:
         DYNAMODB_GAME_TABLE: !Ref GameCacheTable
         DYNAMODB_VECTOR_TABLE: !Ref GameVectorsTable
         DYNAMODB_PREFETCH_TABLE: !Ref PrefetchStatusTable
+        DYNAMODB_PLAYS_TABLE: !Ref PlaysCacheTable
         DYNAMODB_REGION: !Ref AWS::Region
         BGG_ACCESS_TOKEN: !Ref BggAccessToken
         BGG_TIMEOUT: '240'
@@ -166,6 +167,26 @@ Resources:
         - Key: Application
           Value: bgg-game-selector
 
+  PlaysCacheTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${EnvironmentName}-bgg-plays
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: username
+          AttributeType: S
+      KeySchema:
+        - AttributeName: username
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Application
+          Value: bgg-game-selector
+
   # SQS Queue for prefetch jobs
   PrefetchQueue:
     Type: AWS::SQS::Queue
@@ -211,6 +232,8 @@ Resources:
             TableName: !Ref GameVectorsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref PrefetchStatusTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PlaysCacheTable
         - SQSSendMessagePolicy:
             QueueName: !GetAtt PrefetchQueue.QueueName
       Events:
@@ -317,6 +340,8 @@ Resources:
             TableName: !Ref GameVectorsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref PrefetchStatusTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PlaysCacheTable
         - SQSPollerPolicy:
             QueueName: !GetAtt PrefetchQueue.QueueName
       Events:
@@ -509,6 +534,12 @@ Outputs:
     Value: !Ref PrefetchStatusTable
     Export:
       Name: !Sub ${EnvironmentName}-bgg-prefetch-status-table
+
+  DynamoDBPlaysTableName:
+    Description: DynamoDB table name for plays cache
+    Value: !Ref PlaysCacheTable
+    Export:
+      Name: !Sub ${EnvironmentName}-bgg-plays-table
 
   PrefetchQueueUrl:
     Description: SQS queue URL for prefetch jobs

--- a/src/main/scala/bgg/bggapi/GameService.scala
+++ b/src/main/scala/bgg/bggapi/GameService.scala
@@ -64,13 +64,18 @@ class GameService(
           plays
         }
 
+  private val PlaysCacheTtlSeconds = 24L * 3600
+
   def fetchAndCachePlays(username: String): Unit =
-    fetchAllPlays(username) match
-      case Right(plays) =>
-        playsCache.save(username, plays)
-        logger.info(s"Fetched and cached ${plays.size} plays for $username")
-      case Left(err) =>
-        logger.warn(s"Failed to fetch plays for $username: $err")
+    if playsCache.isFresh(username, PlaysCacheTtlSeconds) then
+      logger.debug(s"Plays cache for $username is fresh, skipping fetch")
+    else
+      fetchAllPlays(username) match
+        case Right(plays) =>
+          playsCache.save(username, plays)
+          logger.info(s"Fetched and cached ${plays.size} plays for $username")
+        case Left(err) =>
+          logger.warn(s"Failed to fetch plays for $username: $err")
 
   private val MaxPlayPages = 200
 

--- a/src/main/scala/bgg/cache/DynamoDbCacheProvider.scala
+++ b/src/main/scala/bgg/cache/DynamoDbCacheProvider.scala
@@ -4,8 +4,11 @@ import bgg.config.AwsConfig
 import bgg.store.{DynamoDbVectorStore, VectorStore}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
-class DynamoDbCacheProvider(client: DynamoDbClient, aws: AwsConfig) extends CacheProvider:
+import java.time.Instant
+
+class DynamoDbCacheProvider(client: DynamoDbClient, aws: AwsConfig, clock: () => Instant = () => Instant.now())
+    extends CacheProvider:
   val gameCache: GameCache = DynamoDbGameCache(client, aws.dynamoGameTable)
   val vectorStore: VectorStore = DynamoDbVectorStore(client, aws.dynamoVectorTable)
   val requestCache: RequestCache = DynamoDbRequestCache(client, aws.dynamoRequestTable)
-  val playsCache: PlaysCache = DynamoDbPlaysCache(client, aws.dynamoPlaysTable)
+  val playsCache: PlaysCache = DynamoDbPlaysCache(client, aws.dynamoPlaysTable, clock)

--- a/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
@@ -8,9 +8,12 @@ import io.circe.{Decoder, Encoder}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
 
+import java.time.Instant
 import scala.jdk.CollectionConverters.*
 
-class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String) extends PlaysCache with StrictLogging:
+class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () => Instant = () => Instant.now())
+    extends PlaysCache
+    with StrictLogging:
 
   private given Logger = logger
   private given Encoder[List[PlayData]] = Encoder.encodeList(PlayData.encoder)
@@ -38,10 +41,16 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String) extends Play
     yield bgg.domain.PlayPlayer(username, name, score, win)
   }
 
+  private val TtlDays = 7L
+
   def save(username: String, plays: List[PlayData]): Unit =
+    val now = clock()
+    val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
     val item = Map(
       "username" -> AttributeValue.fromS(username.toLowerCase),
-      "data" -> AttributeValue.fromS(plays.asJson.noSpaces)
+      "data" -> AttributeValue.fromS(plays.asJson.noSpaces),
+      "cached_at" -> AttributeValue.fromN(now.getEpochSecond.toString),
+      "ttl" -> AttributeValue.fromN(ttl.toString)
     ).asJava
 
     val request = PutItemRequest.builder().tableName(tableName).item(item).build()
@@ -62,3 +71,21 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String) extends Play
     tryAwsCall(client.getItem(request), s"Error loading plays for $username")
       .filter(_.hasItem)
       .flatMap(response => decodeJson[List[PlayData]](response.item().get("data").s(), s"plays for $username"))
+
+  def isFresh(username: String, maxAgeSeconds: Long): Boolean =
+    val request = GetItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(Map("username" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .projectionExpression("cached_at")
+      .build()
+
+    tryAwsCall(client.getItem(request), s"Error checking freshness for $username")
+      .filter(_.hasItem)
+      .flatMap { response =>
+        Option(response.item().get("cached_at")).map(_.n().toLong)
+      }
+      .exists { cachedAt =>
+        val age = clock().getEpochSecond - cachedAt
+        age < maxAgeSeconds
+      }

--- a/src/main/scala/bgg/cache/PlaysCache.scala
+++ b/src/main/scala/bgg/cache/PlaysCache.scala
@@ -5,7 +5,9 @@ import bgg.domain.PlayData
 trait PlaysCache:
   def save(username: String, plays: List[PlayData]): Unit
   def load(username: String): Option[List[PlayData]]
+  def isFresh(username: String, maxAgeSeconds: Long): Boolean
 
 class NoOpPlaysCache extends PlaysCache:
   def save(username: String, plays: List[PlayData]): Unit = ()
   def load(username: String): Option[List[PlayData]] = None
+  def isFresh(username: String, maxAgeSeconds: Long): Boolean = false

--- a/src/main/scala/bgg/routes/ApiEndpoints.scala
+++ b/src/main/scala/bgg/routes/ApiEndpoints.scala
@@ -122,14 +122,9 @@ class ApiEndpoints(
   // GET /plays/:username
   val playsEndpoint = baseEndpoint.get
     .in("plays" / path[String]("username"))
-    .in(headers)
     .out(jsonBody[List[Json]])
-    .handle { (username, hdrs) =>
-      val filters = HeaderFilters.fromHeaders(hdrs)
+    .handle { username =>
       gameService.resolvePlays(username).map { plays =>
-        val distinctIds = plays.map(_.gameId).distinct
-        val gameMap = gameCache.loadBatch(distinctIds).map(g => (g.id, g)).toMap
-
         plays.groupBy(_.gameId).toList.map { (gameId, gamePlays) =>
           val totalPlays = gamePlays.map(_.quantity).sum
           val playsArray = Json.fromValues(gamePlays.map { p =>
@@ -147,15 +142,11 @@ class ApiEndpoints(
               })
             )
           })
-          val gameJson = gameMap.get(gameId).map { game =>
-            FieldReduction(List(game), filters.fieldWhitelist).head
-          }
           Json.obj(
             "game_id" -> Encoder[GameId].apply(gameId),
             "game_name" -> Json.fromString(gamePlays.head.gameName),
             "total_plays" -> Json.fromInt(totalPlays),
-            "plays" -> playsArray,
-            "game" -> gameJson.getOrElse(Json.Null)
+            "plays" -> playsArray
           )
         }
       }

--- a/src/test/scala/bgg/bggapi/GameServiceSpec.scala
+++ b/src/test/scala/bgg/bggapi/GameServiceSpec.scala
@@ -27,10 +27,11 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     vectorStore.close()
     Files.deleteIfExists(Paths.get(vectorDb)): Unit
 
-  private class MemoryPlaysCache extends PlaysCache:
+  private class MemoryPlaysCache(fresh: Boolean = false) extends PlaysCache:
     val store: mutable.Map[String, List[PlayData]] = mutable.Map.empty
     def save(username: String, plays: List[PlayData]): Unit = store(username) = plays
     def load(username: String): Option[List[PlayData]] = store.get(username)
+    def isFresh(username: String, maxAgeSeconds: Long): Boolean = fresh && store.contains(username)
 
   private class MemoryRequestCache extends RequestCache:
     private val store: mutable.Map[String, String] = mutable.Map.empty
@@ -137,7 +138,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       result shouldBe Right(List(testPlay))
 
   "fetchAndCachePlays" should:
-    "fetch and save plays to cache" in:
+    "fetch and save plays to cache when not cached" in:
       val playsCache = MemoryPlaysCache()
       val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
       val client = stubClient(playsPage1 = Right(List(testPlay)))
@@ -146,6 +147,27 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       service.fetchAndCachePlays("dave")
 
       playsCache.store.get("dave") shouldBe Some(List(testPlay))
+
+    "skip fetch when cache is fresh" in:
+      var fetchCount = 0
+      val client = new BggClient:
+        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] =
+          fetchCount += 1
+          Right(List(testPlay))
+
+      val playsCache = MemoryPlaysCache(fresh = true)
+      playsCache.save("dave", List(testPlay))
+      val caches = TestCacheProvider(gameCache, vectorStore, playsCache = playsCache)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.fetchAndCachePlays("dave")
+
+      fetchCount shouldBe 0
 
     "not crash when fetch fails" in:
       val playsCache = MemoryPlaysCache()


### PR DESCRIPTION
## Summary

- **Root cause:** The `production-bgg-plays` DynamoDB table was never provisioned in the SAM template, every `PlaysCache` operation silently failed (`tryAwsCall` swallowed `ResourceNotFoundException`), causing all plays requests to hit BGG directly (46 API calls today alone)
- Adds `PlaysCacheTable` to SAM with DynamoDB TTL (7-day auto-expiry), IAM policies for both Lambdas, and `DYNAMODB_PLAYS_TABLE` env var
- Prefetch worker now checks `isFresh(username, 24h)` before re-fetching, skips if cache is less than 24 hours old
- `/plays` endpoint serves from cache on hit, only fetches BGG on cold miss (never refreshes stale data on the request path)
- Removes game enrichment from plays response, redundant since plays only contain games the user has already played

## Test plan

- [x] All 280 unit tests pass
- [x] Deployed to production, `production-bgg-plays` table created successfully
- [x] Verified `/plays/teqqles` returns 85 games with play counts
- [x] Verified `/plays/dragonc` returns 286 games with play counts  
- [x] Second call to `/plays/teqqles` served from cache (500ms vs multi-second first fetch)
- [x] Response no longer includes `game` field (enrichment removed)