### PR TITLE
Replace monolithic prefetch worker with Step Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,19 @@ The server starts on `http://localhost:8080`. Use `CACHE_BACKEND=memory` for eph
 
 ```
               POST /prefetch
-Client ──────────────────────────────────────────────────┐
-  │                                                      v
-  │ GET /collection, /geeklist, /recommendations   ┌──────────┐
-  v                                                │ SQS Queue│
-┌─────────────────────────┐                        └─────┬────┘
-│  API Lambda             │                              │
-│  (Tapir + Netty Sync)   │                              v
-│  GraalVM native binary  │                   ┌────────────────────┐
-└───────────┬─────────────┘                   │ Prefetch Worker    │
-            │                                 │ Lambda (15m timeout)│
-            │                                 └──────────┬─────────┘
-            v                                            │
-┌─────────────────────────┐                              │
-│  BGG XML API            │ <────────────────────────────┘
+Client ──────────────────────────────────────────────────────┐
+  │                                                          v
+  │ GET /collection, /geeklist, /recommendations   ┌─────────────────┐
+  v                                                │ Step Functions   │
+┌─────────────────────────┐                        │ (STANDARD)       │
+│  API Lambda             │                        └────────┬────────┘
+│  (Tapir + Netty Sync)   │                                 │
+│  GraalVM native binary  │         ┌───────────────────────┼──────────────┐
+└───────────┬─────────────┘         │                       │              │
+            │                  CollectionFetch         PlaysFetchPage   GameFetch
+            v                  (ID resolution)        (page loop)      (batched)
+┌─────────────────────────┐         │                       │              │
+│  BGG XML API            │ <───────┴───────────────────────┴──────────────┘
 │  (v1 geeklists, v2 all) │
 └───────────┬─────────────┘
             │
@@ -66,6 +65,7 @@ Client ────────────────────────�
 ┌───────────────────────────────────────────┐
 │  DynamoDB (prod) / SQLite (local)         │
 │  ├─ Game Cache (7 day TTL)                │
+│  ├─ Plays Cache (chunked, incremental)    │
 │  ├─ Vector Store (game embeddings)        │
 │  └─ Prefetch Status (per-status TTLs)     │
 └───────────────────────────────────────────┘
@@ -74,6 +74,7 @@ Client ────────────────────────�
 ### Caching Strategy
 
 - **Game Cache**: Individual game details cached for 7 days. Fetches from BGG on miss.
+- **Plays Cache**: Chunked per-page storage with incremental updates. Only fetches new plays since the last cached play ID.
 - **Vector Store**: Game feature vectors for the recommendation engine. Updated on cache writes when the game has enough ratings.
 - **Prefetch Status**: Tracks async BGG fetch jobs with per-status TTLs. Avoids the API Gateway 29s timeout on slow BGG responses.
 
@@ -141,13 +142,21 @@ GET /game/174430
 {"error": "Game 99999 not found"}
 ```
 
+### GET /hot
+
+Trending games from BGG's hotness list.
+
+### GET /plays/:username
+
+Play history for a BGG user, grouped by game. Includes metadata indicating whether the plays fetch is still in progress.
+
 ### GET /search/:query
 
 Search BGG for games by name (minimum 3 characters).
 
 ### POST /prefetch
 
-Queue an async BGG fetch. Returns immediately so the frontend doesn't block.
+Starts an async prefetch via Step Functions. Returns immediately so the frontend doesn't block.
 
 ```json
 {"source_type": "collection", "source_id": "username"}
@@ -204,7 +213,7 @@ All config is via environment variables (with defaults in `application.conf`):
 | `GAME_CACHE_DURATION` | `604800` | Game cache TTL (seconds) |
 | `VECTOR_MIN_RATINGS` | `100` | Min ratings for vectorization |
 | `AWS_REGION` | `us-east-1` | AWS region |
-| `PREFETCH_SQS_URL` | *(required in prod)* | SQS queue URL (API Lambda sends prefetch jobs here) |
+| `PREFETCH_STATE_MACHINE_ARN` | *(required in prod)* | Step Functions state machine ARN for prefetch |
 | `SERVER_HOST` | `0.0.0.0` | Server bind host |
 | `SERVER_PORT` | `8080` | Server bind port |
 
@@ -227,7 +236,7 @@ make run        # Run locally (fat jar, JVM mode)
 - **sttp client4** — synchronous HTTP client for BGG API
 - **Circe** — JSON codec derivation
 - **scala-xml** — BGG XML API parsing
-- **AWS SDK v2** — DynamoDB, SQS (url-connection-client for GraalVM compatibility)
+- **AWS SDK v2** — DynamoDB, Step Functions (url-connection-client for GraalVM compatibility)
 - **SQLite** — local dev/test cache backend
 - **ScalaTest + ScalaMock** — testing
 
@@ -272,9 +281,10 @@ sam deploy \
 The SAM template provisions:
 - API Gateway (rate-limited, CloudWatch logging)
 - API Lambda (native binary, 512 MB, 30s timeout)
-- Prefetch Worker Lambda (native binary, 512 MB, 15m timeout, SQS-triggered)
+- Step Functions state machine (STANDARD, orchestrates prefetch)
+- 5 worker Lambdas (CollectionFetch, PlaysFetchPage, GameFetch, BatchPreparer, StatusUpdater)
 - DynamoDB tables (PAY_PER_REQUEST, TTL-enabled)
-- SQS queue + dead-letter queue
+- EventBridge rule (weekly hot list warm)
 - CloudWatch alarms for free-tier monitoring
 
 ### Cost

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val root = (project in file("."))
       // AWS SDK v2 — url-connection-client is sync and GraalVM-friendly (no Netty)
       "software.amazon.awssdk"       % "dynamodb"                 % "2.46.11",
       "software.amazon.awssdk"       % "sqs"                      % "2.46.11",
+      "software.amazon.awssdk"       % "sfn"                      % "2.46.11",
       "software.amazon.awssdk"       % "url-connection-client"    % "2.46.11",
       // SQLite (local dev / tests)
       "org.xerial"                   % "sqlite-jdbc"              % "3.45.1.0",
@@ -82,6 +83,7 @@ lazy val root = (project in file("."))
       "bgg\\.lambda\\.PrefetchWorker",
       "bgg\\.lambda\\.PrefetchWorkerLogic\\$",
       "bgg\\.routes\\.AwsSqsSender",
+      "bgg\\.routes\\.StepFunctionsTrigger",
       "bgg\\.routes\\.ErrorOutput.*",
       "bgg\\.cache\\.SqliteCacheProvider",
       "bgg\\.cache\\.MemoryCacheProvider",

--- a/deployment/DEPLOYMENT.md
+++ b/deployment/DEPLOYMENT.md
@@ -69,10 +69,15 @@ The SAM template provisions:
 | Resource | Purpose |
 |----------|---------|
 | API Lambda | Native binary, 512 MB, 30s timeout |
-| Prefetch Worker Lambda | Native binary, 512 MB, 15m timeout, SQS-triggered |
+| Step Functions state machine | Orchestrates prefetch (collection → games → plays) |
+| CollectionFetch Lambda | Resolves game IDs from BGG (300s timeout) |
+| PlaysFetchPage Lambda | Fetches one page of plays incrementally (120s timeout) |
+| GameFetch Lambda | Fetches game details in parallel batches of 20 (300s timeout) |
+| BatchPreparer Lambda | Filters cached IDs, splits into 300-game chunks (30s timeout) |
+| StatusUpdater Lambda | Writes prefetch status transitions (10s timeout) |
 | API Gateway | REST API with rate limiting and CloudWatch logging |
-| DynamoDB tables (x4) | Request cache, game cache, vectors, prefetch status |
-| SQS queue + DLQ | Async prefetch jobs |
+| DynamoDB tables (x5) | Request cache, game cache, plays cache, vectors, prefetch status |
+| EventBridge rule | Weekly hot list warm via Step Functions |
 | CloudWatch alarms | Free-tier usage warnings |
 
 ## Cost
@@ -82,7 +87,7 @@ The SAM template provisions:
 | Lambda | 1M requests | ~500K | $0.00 |
 | API Gateway | 1M calls | ~500K | $0.00 |
 | DynamoDB | 25GB, 25 RCU/WCU | ~5GB | $0.00 |
-| SQS | 1M requests | ~10K | $0.00 |
+| Step Functions | 4,000 transitions | ~1,000 | $0.00 |
 | **Total** | | | **$0.00** |
 
 ## Updating
@@ -113,7 +118,7 @@ This deletes all resources including DynamoDB tables — cached data will be los
 
 ### Lambda Timeout
 
-The API function has a 30s timeout (API Gateway hard limit). Slow BGG fetches should use `POST /prefetch` — the worker Lambda has a 15-minute timeout.
+The API function has a 30s timeout (API Gateway hard limit). Slow BGG fetches should use `POST /prefetch` — the Step Functions state machine orchestrates individual Lambdas (each with 30s-300s timeouts) and has no overall time limit.
 
 ### Cold Start > 1s
 

--- a/deployment/IAM-SETUP.md
+++ b/deployment/IAM-SETUP.md
@@ -43,7 +43,8 @@ All permissions are scoped to `production-bgg-*` resources:
 | Lambda | Function management | `production-bgg-*` functions |
 | API Gateway | REST API management | All REST APIs (can't scope by name) |
 | DynamoDB | Table management + TTL | `production-bgg-*` tables |
-| SQS | Queue management | `production-bgg-*` queues |
+| Step Functions | State machine management | `production-bgg-*` state machines |
+| EventBridge | Rule management | `production-bgg-*` rules |
 | CloudWatch | Logs + alarms | `production-bgg-*` resources |
 | IAM | Role creation | `production-bgg-*` and SAM roles |
 | S3 | Deployment artifacts | SAM-managed buckets only |

--- a/deployment/iam-policy.json
+++ b/deployment/iam-policy.json
@@ -89,6 +89,7 @@
       ],
       "Resource": [
         "arn:aws:logs:*:*:log-group:/aws/lambda/production-bgg-*",
+        "arn:aws:logs:*:*:log-group:/aws/states/production-bgg-*",
         "arn:aws:cloudwatch:*:*:alarm:production-bgg-*"
       ]
     },

--- a/deployment/iam-policy.json
+++ b/deployment/iam-policy.json
@@ -45,12 +45,20 @@
       "Resource": "*"
     },
     {
-      "Sid": "SQSManagement",
+      "Sid": "StepFunctionsManagement",
       "Effect": "Allow",
       "Action": [
-        "sqs:*"
+        "states:*"
       ],
-      "Resource": "arn:aws:sqs:*:*:production-bgg-*"
+      "Resource": "arn:aws:states:*:*:stateMachine:production-bgg-*"
+    },
+    {
+      "Sid": "EventBridgeManagement",
+      "Effect": "Allow",
+      "Action": [
+        "events:*"
+      ],
+      "Resource": "arn:aws:events:*:*:rule/production-bgg-*"
     },
     {
       "Sid": "APIGatewayManagement",

--- a/deployment/prefetch-state-machine.asl.json
+++ b/deployment/prefetch-state-machine.asl.json
@@ -1,0 +1,308 @@
+{
+  "Comment": "BGG Prefetch State Machine — orchestrates collection/plays/game fetching",
+  "StartAt": "SetStatusProcessing",
+  "States": {
+    "SetStatusProcessing": {
+      "Type": "Task",
+      "Resource": "${StatusUpdaterArn}",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId",
+        "status": "processing"
+      },
+      "ResultPath": null,
+      "Next": "RouteBySourceType",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "SetStatusFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+
+    "RouteBySourceType": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.sourceType",
+          "StringEquals": "collection",
+          "Next": "CollectionWorkflow"
+        },
+        {
+          "Variable": "$.sourceType",
+          "StringEquals": "geeklist",
+          "Next": "FetchIds"
+        },
+        {
+          "Variable": "$.sourceType",
+          "StringEquals": "hot",
+          "Next": "FetchIds"
+        }
+      ],
+      "Default": "SetStatusFailed"
+    },
+
+    "CollectionWorkflow": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "FetchCollectionIds",
+          "States": {
+            "FetchCollectionIds": {
+              "Type": "Task",
+              "Resource": "${CollectionFetchArn}",
+              "Parameters": {
+                "sourceType.$": "$.sourceType",
+                "sourceId.$": "$.sourceId"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": ["BggRateLimitedException"],
+                  "IntervalSeconds": 30,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2.0
+                },
+                {
+                  "ErrorEquals": ["States.Timeout"],
+                  "IntervalSeconds": 60,
+                  "MaxAttempts": 2,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "InitPlaysLoop",
+          "States": {
+            "InitPlaysLoop": {
+              "Type": "Pass",
+              "Parameters": {
+                "username.$": "$.sourceId",
+                "page": 1,
+                "sourceType.$": "$.sourceType",
+                "sourceId.$": "$.sourceId"
+              },
+              "Next": "FetchPlaysPage"
+            },
+            "FetchPlaysPage": {
+              "Type": "Task",
+              "Resource": "${PlaysFetchPageArn}",
+              "Retry": [
+                {
+                  "ErrorEquals": ["BggRateLimitedException"],
+                  "IntervalSeconds": 30,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2.0
+                }
+              ],
+              "Next": "CheckPlaysDone"
+            },
+            "CheckPlaysDone": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.done",
+                  "BooleanEquals": true,
+                  "Next": "PlaysDone"
+                }
+              ],
+              "Default": "PrepareNextPlaysPage"
+            },
+            "PrepareNextPlaysPage": {
+              "Type": "Pass",
+              "Parameters": {
+                "username.$": "$.username",
+                "page.$": "$.nextPage",
+                "sourceType.$": "$.sourceType",
+                "sourceId.$": "$.sourceId",
+                "cachedMaxPlayId.$": "$.cachedMaxPlayId"
+              },
+              "Next": "FetchPlaysPage"
+            },
+            "PlaysDone": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        }
+      ],
+      "ResultPath": "$.parallelResults",
+      "Next": "ExtractGameIds",
+      "Catch": [
+        {
+          "ErrorEquals": ["BggUserNotFoundException"],
+          "Next": "SetStatusNotFound",
+          "ResultPath": "$.error"
+        },
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "SetStatusFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+
+    "FetchIds": {
+      "Type": "Task",
+      "Resource": "${CollectionFetchArn}",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId"
+      },
+      "ResultPath": "$.fetchResult",
+      "Retry": [
+        {
+          "ErrorEquals": ["BggRateLimitedException"],
+          "IntervalSeconds": 30,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        },
+        {
+          "ErrorEquals": ["States.Timeout"],
+          "IntervalSeconds": 60,
+          "MaxAttempts": 2,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Next": "ExtractGameIdsFromFetch",
+      "Catch": [
+        {
+          "ErrorEquals": ["BggUserNotFoundException", "BggListNotFoundException"],
+          "Next": "SetStatusNotFound",
+          "ResultPath": "$.error"
+        },
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "SetStatusFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+
+    "ExtractGameIdsFromFetch": {
+      "Type": "Pass",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId",
+        "gameIds.$": "$.fetchResult.gameIds"
+      },
+      "Next": "PrepareBatches"
+    },
+
+    "ExtractGameIds": {
+      "Type": "Pass",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId",
+        "gameIds.$": "$.parallelResults[0].gameIds"
+      },
+      "Next": "PrepareBatches"
+    },
+
+    "PrepareBatches": {
+      "Type": "Task",
+      "Resource": "${BatchPreparerArn}",
+      "ResultPath": "$.batches",
+      "Next": "CheckBatchesEmpty",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "SetStatusFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+
+    "CheckBatchesEmpty": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.batches[0]",
+          "IsPresent": false,
+          "Next": "SetStatusCompleted"
+        }
+      ],
+      "Default": "ProcessGameBatches"
+    },
+
+    "ProcessGameBatches": {
+      "Type": "Map",
+      "ItemsPath": "$.batches",
+      "MaxConcurrency": 1,
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "FetchGameBatch",
+        "States": {
+          "FetchGameBatch": {
+            "Type": "Task",
+            "Resource": "${GameFetchArn}",
+            "Retry": [
+              {
+                "ErrorEquals": ["BggRateLimitedException"],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 3,
+                "BackoffRate": 2.0
+              },
+              {
+                "ErrorEquals": ["States.Timeout"],
+                "IntervalSeconds": 60,
+                "MaxAttempts": 2,
+                "BackoffRate": 1.5
+              }
+            ],
+            "End": true
+          }
+        }
+      },
+      "ResultPath": "$.batchResults",
+      "Next": "SetStatusCompleted",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "SetStatusFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+
+    "SetStatusCompleted": {
+      "Type": "Task",
+      "Resource": "${StatusUpdaterArn}",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId",
+        "status": "completed"
+      },
+      "End": true
+    },
+
+    "SetStatusNotFound": {
+      "Type": "Task",
+      "Resource": "${StatusUpdaterArn}",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId",
+        "status": "not_found",
+        "reason.$": "$.error.Cause"
+      },
+      "End": true
+    },
+
+    "SetStatusFailed": {
+      "Type": "Task",
+      "Resource": "${StatusUpdaterArn}",
+      "Parameters": {
+        "sourceType.$": "$.sourceType",
+        "sourceId.$": "$.sourceId",
+        "status": "failed",
+        "reason.$": "$.error.Cause"
+      },
+      "End": true
+    }
+  }
+}

--- a/deployment/prefetch-state-machine.asl.json
+++ b/deployment/prefetch-state-machine.asl.json
@@ -244,9 +244,9 @@
             "Retry": [
               {
                 "ErrorEquals": ["BggRateLimitedException"],
-                "IntervalSeconds": 30,
-                "MaxAttempts": 3,
-                "BackoffRate": 2.0
+                "IntervalSeconds": 60,
+                "MaxAttempts": 5,
+                "BackoffRate": 1.5
               },
               {
                 "ErrorEquals": ["States.Timeout"],

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -48,7 +48,7 @@ Conditions:
 Globals:
   Function:
     Timeout: 30
-    MemorySize: 512
+    MemorySize: 1024
     Runtime: provided.al2023
     Architectures:
       - x86_64
@@ -280,6 +280,7 @@ Resources:
       Environment:
         Variables:
           LAMBDA_HANDLER: GameFetch
+          BGG_RETRIES: '20'
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref GameCacheTable

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -67,7 +67,7 @@ Globals:
         BGG_RETRY_DELAY: '10'
         REQUEST_CACHE_DURATION: '86400'
         GAME_CACHE_DURATION: '604800'
-        PREFETCH_SQS_URL: !Ref PrefetchQueue
+        PREFETCH_SQS_URL: ''
 
 Resources:
   # IAM Role for API Gateway to write CloudWatch Logs (Account-level, one-time setup)
@@ -175,9 +175,13 @@ Resources:
       AttributeDefinitions:
         - AttributeName: username
           AttributeType: S
+        - AttributeName: page
+          AttributeType: N
       KeySchema:
         - AttributeName: username
           KeyType: HASH
+        - AttributeName: page
+          KeyType: RANGE
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -187,32 +191,168 @@ Resources:
         - Key: Application
           Value: bgg-game-selector
 
-  # SQS Queue for prefetch jobs
-  PrefetchQueue:
-    Type: AWS::SQS::Queue
+  # Step Functions State Machine for prefetch orchestration
+  PrefetchStateMachine:
+    Type: AWS::Serverless::StateMachine
     Properties:
-      QueueName: !Sub ${EnvironmentName}-bgg-prefetch-queue
-      VisibilityTimeout: 960
-      MessageRetentionPeriod: 3600
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt PrefetchDeadLetterQueue.Arn
-        maxReceiveCount: 3
+      Name: !Sub ${EnvironmentName}-bgg-prefetch
+      DefinitionUri: ./prefetch-state-machine.asl.json
+      DefinitionSubstitutions:
+        CollectionFetchArn: !GetAtt CollectionFetchFunction.Arn
+        PlaysFetchPageArn: !GetAtt PlaysFetchPageFunction.Arn
+        GameFetchArn: !GetAtt GameFetchFunction.Arn
+        BatchPreparerArn: !GetAtt BatchPreparerFunction.Arn
+        StatusUpdaterArn: !GetAtt StatusUpdaterFunction.Arn
+      Type: STANDARD
+      Logging:
+        Level: ERROR
+        IncludeExecutionData: false
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt PrefetchStateMachineLogGroup.Arn
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref CollectionFetchFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref PlaysFetchPageFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref GameFetchFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref BatchPreparerFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref StatusUpdaterFunction
+        - CloudWatchLogsFullAccess
       Tags:
-        - Key: Environment
-          Value: !Ref EnvironmentName
-        - Key: Application
-          Value: bgg-game-selector
+        Environment: !Ref EnvironmentName
 
-  PrefetchDeadLetterQueue:
-    Type: AWS::SQS::Queue
+  PrefetchStateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
     Properties:
-      QueueName: !Sub ${EnvironmentName}-bgg-prefetch-dlq
-      MessageRetentionPeriod: 86400
+      LogGroupName: !Sub /aws/states/${EnvironmentName}-bgg-prefetch
+      RetentionInDays: 7
+
+  # Step Functions worker Lambdas
+  CollectionFetchFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${EnvironmentName}-bgg-collection-fetch
+      CodeUri: ./bgg-api-native.zip
+      Handler: bgg.lambda.CollectionFetch
+      Description: Fetches game IDs from BGG collection/geeklist/hot
+      Timeout: 300
+      Environment:
+        Variables:
+          LAMBDA_HANDLER: CollectionFetch
+          BGG_RETRIES: '20'
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RequestCacheTable
       Tags:
-        - Key: Environment
-          Value: !Ref EnvironmentName
-        - Key: Application
-          Value: bgg-game-selector
+        Environment: !Ref EnvironmentName
+
+  PlaysFetchPageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${EnvironmentName}-bgg-plays-fetch-page
+      CodeUri: ./bgg-api-native.zip
+      Handler: bgg.lambda.PlaysFetchPage
+      Description: Fetches one page of plays and appends to cache
+      Timeout: 120
+      Environment:
+        Variables:
+          LAMBDA_HANDLER: PlaysFetchPage
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PlaysCacheTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PrefetchStatusTable
+      Tags:
+        Environment: !Ref EnvironmentName
+
+  GameFetchFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${EnvironmentName}-bgg-game-fetch
+      CodeUri: ./bgg-api-native.zip
+      Handler: bgg.lambda.GameFetch
+      Description: Fetches game details in parallel batches of 20
+      Timeout: 300
+      Environment:
+        Variables:
+          LAMBDA_HANDLER: GameFetch
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref GameCacheTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref GameVectorsTable
+      Tags:
+        Environment: !Ref EnvironmentName
+
+  BatchPreparerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${EnvironmentName}-bgg-batch-preparer
+      CodeUri: ./bgg-api-native.zip
+      Handler: bgg.lambda.BatchPreparer
+      Description: Filters cached games and splits IDs into 300-chunks
+      Timeout: 30
+      Environment:
+        Variables:
+          LAMBDA_HANDLER: BatchPreparer
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref GameCacheTable
+      Tags:
+        Environment: !Ref EnvironmentName
+
+  StatusUpdaterFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${EnvironmentName}-bgg-status-updater
+      CodeUri: ./bgg-api-native.zip
+      Handler: bgg.lambda.StatusUpdater
+      Description: Updates prefetch status in DynamoDB
+      Timeout: 10
+      Environment:
+        Variables:
+          LAMBDA_HANDLER: StatusUpdater
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PrefetchStatusTable
+      Tags:
+        Environment: !Ref EnvironmentName
+
+  # EventBridge rule for weekly hot list cache warming
+  WeeklyHotListWarmRule:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: cron(0 4 ? * MON *)
+      Description: Warm the hot games cache every Monday at 4am UTC
+      Targets:
+        - Id: PrefetchStateMachine
+          Arn: !GetAtt PrefetchStateMachine.Arn
+          RoleArn: !GetAtt EventBridgeStepFunctionsRole.Arn
+          Input: '{"sourceType":"hot","sourceId":"trending"}'
+
+  EventBridgeStepFunctionsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${EnvironmentName}-bgg-eventbridge-sfn-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StartExecution
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: states:StartExecution
+                Resource: !GetAtt PrefetchStateMachine.Arn
 
   # API Lambda — GraalVM native binary, custom runtime (provided.al2023)
   # SyncLambdaHandler decodes API Gateway REST API events directly via tapir-aws-lambda-core.
@@ -223,6 +363,10 @@ Resources:
       CodeUri: ./bgg-api-native.zip
       Handler: bgg.lambda.ApiLambdaHandler
       Description: BGG Game Selector API v3 - Scala/Tapir native Lambda
+
+      Environment:
+        Variables:
+          PREFETCH_STATE_MACHINE_ARN: !GetAtt PrefetchStateMachine.Arn
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref RequestCacheTable
@@ -234,8 +378,10 @@ Resources:
             TableName: !Ref PrefetchStatusTable
         - DynamoDBCrudPolicy:
             TableName: !Ref PlaysCacheTable
-        - SQSSendMessagePolicy:
-            QueueName: !GetAtt PrefetchQueue.QueueName
+        - Statement:
+            - Effect: Allow
+              Action: states:StartExecution
+              Resource: !GetAtt PrefetchStateMachine.Arn
       Events:
         HealthCheck:
           Type: Api
@@ -319,45 +465,6 @@ Resources:
       Tags:
         Environment: !Ref EnvironmentName
 
-  # Worker Lambda — triggered by SQS, custom runtime with LAMBDA_HANDLER to select worker path
-  PrefetchWorkerFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub ${EnvironmentName}-bgg-prefetch-worker
-      CodeUri: ./bgg-api-native.zip
-      Handler: bgg.lambda.PrefetchWorker
-      Description: BGG prefetch worker v3 — fetches BGG data async and warms the cache
-      Timeout: 900
-      Environment:
-        Variables:
-          LAMBDA_HANDLER: PrefetchWorker
-      Policies:
-        - DynamoDBCrudPolicy:
-            TableName: !Ref RequestCacheTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref GameCacheTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref GameVectorsTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref PrefetchStatusTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref PlaysCacheTable
-        - SQSPollerPolicy:
-            QueueName: !GetAtt PrefetchQueue.QueueName
-      Events:
-        PrefetchQueueTrigger:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt PrefetchQueue.Arn
-            BatchSize: 1
-        WeeklyHotListWarm:
-          Type: Schedule
-          Properties:
-            Schedule: cron(0 4 ? * MON *)
-            Description: Warm the hot games cache every Monday at 4am UTC
-            Input: '{"Records":[{"body":"{\"source_type\":\"hot\",\"source_id\":\"trending\"}"}]}'
-      Tags:
-        Environment: !Ref EnvironmentName
 
   # API Gateway
   ApiGateway:
@@ -505,11 +612,11 @@ Outputs:
     Export:
       Name: !Sub ${EnvironmentName}-bgg-function-arn
 
-  WorkerFunctionArn:
-    Description: Prefetch Worker Lambda Function ARN
-    Value: !GetAtt PrefetchWorkerFunction.Arn
+  PrefetchStateMachineArn:
+    Description: Prefetch Step Functions State Machine ARN
+    Value: !GetAtt PrefetchStateMachine.Arn
     Export:
-      Name: !Sub ${EnvironmentName}-bgg-worker-function-arn
+      Name: !Sub ${EnvironmentName}-bgg-prefetch-state-machine-arn
 
   DynamoDBRequestTableName:
     Description: DynamoDB table name for request cache
@@ -541,14 +648,3 @@ Outputs:
     Export:
       Name: !Sub ${EnvironmentName}-bgg-plays-table
 
-  PrefetchQueueUrl:
-    Description: SQS queue URL for prefetch jobs
-    Value: !Ref PrefetchQueue
-    Export:
-      Name: !Sub ${EnvironmentName}-bgg-prefetch-queue-url
-
-  PrefetchDeadLetterQueueUrl:
-    Description: SQS dead letter queue URL for failed prefetch jobs
-    Value: !Ref PrefetchDeadLetterQueue
-    Export:
-      Name: !Sub ${EnvironmentName}-bgg-prefetch-dlq-url

--- a/deployment/serverless-template.yaml
+++ b/deployment/serverless-template.yaml
@@ -170,7 +170,7 @@ Resources:
   PlaysCacheTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${EnvironmentName}-bgg-plays
+      TableName: !Sub ${EnvironmentName}-bgg-plays-v2
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: username

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -71,7 +71,7 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "software.amazon.awssdk.services.sqs.SqsClient",
+    "name": "software.amazon.awssdk.services.sfn.SfnClient",
     "queryAllPublicMethods": true
   }
 ]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -43,6 +43,8 @@ aws {
   dynamoPlaysTable = ${?DYNAMODB_PLAYS_TABLE}
   prefetchSqsUrl = ""
   prefetchSqsUrl = ${?PREFETCH_SQS_URL}
+  prefetchStateMachineArn = ""
+  prefetchStateMachineArn = ${?PREFETCH_STATE_MACHINE_ARN}
 }
 
 server {

--- a/src/main/scala/bgg/bggapi/BggClient.scala
+++ b/src/main/scala/bgg/bggapi/BggClient.scala
@@ -4,7 +4,7 @@ import bgg.domain.{Fail, GameData, GameId, PlayData}
 
 trait BggClient:
   def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]]
-  def fetchCollection(username: String): Either[Fail, List[GameId]]
+  def fetchCollection(username: String, retries: Int = 6): Either[Fail, List[GameId]]
   def fetchGeeklist(listId: String): Either[Fail, List[GameId]]
   def fetchHotGames(): Either[Fail, List[GameId]]
   def searchGames(query: String): Either[Fail, List[GameData]]

--- a/src/main/scala/bgg/bggapi/BggXmlClient.scala
+++ b/src/main/scala/bgg/bggapi/BggXmlClient.scala
@@ -47,25 +47,29 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
             Thread.sleep(config.retryDelaySeconds * 1000L)
             attempt(remaining - 1)
           case StatusCode.TooManyRequests =>
-            Left(Fail.BggRateLimited("BGG is rate limiting requests"))
+            logger.debug(s"BGG returned 429, retrying in ${config.retryDelaySeconds * 2}s ($remaining retries left)")
+            Thread.sleep(config.retryDelaySeconds * 2000L)
+            attempt(remaining - 1)
           case code =>
             Left(Fail.IncorrectInput(s"BGG returned unexpected status $code"))
 
     attempt(maxRetries)
 
   def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
-    val results = ids
+    ids
       .grouped(ThingBatchSize)
       .toList
-      .flatMap { batch =>
-        val idStr = batch.map(_.value).mkString(",")
-        getWithRetry(s"$ApiV2Base/thing", Map("id" -> idStr, "stats" -> "1")) match
-          case Left(e) =>
-            logger.error(s"Failed to fetch batch $idStr: $e")
-            Nil
-          case Right(xml) => XmlParser.parseThings(xml)
+      .foldLeft[Either[Fail, List[GameData]]](Right(Nil)) { (acc, batch) =>
+        acc.flatMap { soFar =>
+          val idStr = batch.map(_.value).mkString(",")
+          getWithRetry(s"$ApiV2Base/thing", Map("id" -> idStr, "stats" -> "1")) match
+            case Left(e @ Fail.BggRateLimited(_)) => Left(e)
+            case Left(e) =>
+              logger.error(s"Failed to fetch batch $idStr: $e")
+              Right(soFar)
+            case Right(xml) => Right(soFar ++ XmlParser.parseThings(xml))
+        }
       }
-    Right(results)
 
   def fetchCollection(username: String, retries: Int = config.retries): Either[Fail, List[GameId]] =
     getWithRetry(

--- a/src/main/scala/bgg/bggapi/BggXmlClient.scala
+++ b/src/main/scala/bgg/bggapi/BggXmlClient.scala
@@ -7,6 +7,7 @@ import sttp.client4.*
 import sttp.model.StatusCode
 
 import scala.annotation.tailrec
+import scala.concurrent.duration.*
 import scala.xml.{Elem, XML}
 
 class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient with StrictLogging:
@@ -16,13 +17,17 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
   private val ThingBatchSize = 20
   private val MinSearchLength = 3
   private val SearchResultLimit = 20
+  private val readTimeout = config.timeoutSeconds.seconds
 
   private def authHeaders: Map[String, String] =
     if config.accessToken.nonEmpty then Map("Authorization" -> s"Bearer ${config.accessToken}")
     else Map.empty
 
-  // BGG uses HTTP 202 to signal "try again later" for requests
-  private def getWithRetry(url: String, params: Map[String, String] = Map.empty): Either[Fail, Elem] =
+  private def getWithRetry(
+      url: String,
+      params: Map[String, String] = Map.empty,
+      maxRetries: Int = config.retries
+  ): Either[Fail, Elem] =
     @tailrec
     def attempt(remaining: Int): Either[Fail, Elem] =
       if remaining <= 0 then Left(Fail.BggRateLimited("BGG rate limit exceeded after retries"))
@@ -30,6 +35,7 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
         val response = basicRequest
           .get(uri"$url".withParams(params))
           .headers(authHeaders)
+          .readTimeout(readTimeout)
           .response(asStringAlways)
           .send(backend)
 
@@ -37,7 +43,7 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
           case StatusCode.Ok =>
             Right(XML.loadString(response.body))
           case StatusCode.Accepted =>
-            logger.debug(s"BGG returned 202, retrying in ${config.retryDelaySeconds}s")
+            logger.debug(s"BGG returned 202, retrying in ${config.retryDelaySeconds}s ($remaining retries left)")
             Thread.sleep(config.retryDelaySeconds * 1000L)
             attempt(remaining - 1)
           case StatusCode.TooManyRequests =>
@@ -45,7 +51,7 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
           case code =>
             Left(Fail.IncorrectInput(s"BGG returned unexpected status $code"))
 
-    attempt(config.retries)
+    attempt(maxRetries)
 
   def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
     val results = ids
@@ -61,10 +67,11 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
       }
     Right(results)
 
-  def fetchCollection(username: String): Either[Fail, List[GameId]] =
+  def fetchCollection(username: String, retries: Int = config.retries): Either[Fail, List[GameId]] =
     getWithRetry(
       s"$ApiV2Base/collection",
-      Map("username" -> username, "own" -> "1", "excludesubtype" -> "boardgameexpansion")
+      Map("username" -> username, "own" -> "1", "excludesubtype" -> "boardgameexpansion"),
+      maxRetries = retries
     )
       .flatMap { xml =>
         val items = (xml \ "item")

--- a/src/main/scala/bgg/bggapi/GameService.scala
+++ b/src/main/scala/bgg/bggapi/GameService.scala
@@ -29,11 +29,31 @@ class GameService(
         (cached ++ fetched).sortBy(_.name)
       }
 
+  private val CollectionIdsTtlSeconds = 24L * 3600
+
   def resolveCollection(username: String): Either[Fail, List[GameData]] =
-    bggClient.fetchCollection(username).flatMap(resolveGameIds)
+    val cacheKey = s"collection-ids:$username"
+    requestCache.load[List[Int]](cacheKey) match
+      case Some(ids) =>
+        logger.debug(s"Collection IDs for $username served from request cache (${ids.size} ids)")
+        resolveGameIds(ids.map(GameId(_)))
+      case None =>
+        bggClient.fetchCollection(username).flatMap { ids =>
+          requestCache.save(cacheKey, ids.map(_.value), CollectionIdsTtlSeconds, clock())
+          resolveGameIds(ids)
+        }
 
   def resolveGeeklist(listId: String): Either[Fail, List[GameData]] =
-    bggClient.fetchGeeklist(listId).flatMap(resolveGameIds)
+    val cacheKey = s"geeklist-ids:$listId"
+    requestCache.load[List[Int]](cacheKey) match
+      case Some(ids) =>
+        logger.debug(s"Geeklist IDs for $listId served from request cache (${ids.size} ids)")
+        resolveGameIds(ids.map(GameId(_)))
+      case None =>
+        bggClient.fetchGeeklist(listId).flatMap { ids =>
+          requestCache.save(cacheKey, ids.map(_.value), CollectionIdsTtlSeconds, clock())
+          resolveGameIds(ids)
+        }
 
   private val HotListCacheKey = "hot:trending"
   private val HotListTtlSeconds = 7L * 24 * 3600

--- a/src/main/scala/bgg/cache/DynamoDbGameCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbGameCache.scala
@@ -4,6 +4,7 @@ import bgg.SafeOps.{decodeJson, tryAwsCall}
 import bgg.domain.{GameData, GameId}
 import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.circe.syntax.*
+import ox.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
 
@@ -58,16 +59,22 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String) extends GameC
 
   override def loadBatch(ids: List[GameId]): List[GameData] =
     if ids.isEmpty then return Nil
-    ids.distinct
-      .grouped(BatchGetMaxKeys)
-      .flatMap { chunk =>
-        fetchBatchWithRetry(
-          chunk.map(id => Map("id" -> AttributeValue.fromS(id.asString)).asJava),
-          Nil,
-          BatchGetMaxRetries
-        )
-      }
-      .toList
+    val chunks = ids.distinct.grouped(BatchGetMaxKeys).toList
+    if chunks.size <= 1 then
+      chunks.flatMap(chunk => fetchBatchWithRetry(
+        chunk.map(id => Map("id" -> AttributeValue.fromS(id.asString)).asJava), Nil, BatchGetMaxRetries
+      ))
+    else
+      supervised:
+        val forks = chunks.map { chunk =>
+          forkUnsupervised:
+            fetchBatchWithRetry(
+              chunk.map(id => Map("id" -> AttributeValue.fromS(id.asString)).asJava),
+              Nil,
+              BatchGetMaxRetries
+            )
+        }
+        forks.flatMap(_.join())
 
   @scala.annotation.tailrec
   private def fetchBatchWithRetry(

--- a/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
@@ -67,7 +67,9 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
           .asScala
           .toList
           .flatMap { item =>
-            decodeJson[List[PlayData]](item.get("data").s(), s"plays chunk for $username").getOrElse(Nil)
+            Option(item.get("data")).flatMap(attr =>
+              decodeJson[List[PlayData]](attr.s(), s"plays chunk for $username")
+            ).getOrElse(Nil)
           }
           .sortBy(_.playId)(Ordering[Int].reverse)
       }
@@ -197,7 +199,7 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
       .build()
 
     tryAwsCall(client.query(request), s"Error getting next page for $username")
-      .filter(_.hasItems)
+      .filter(r => r.hasItems && !r.items().isEmpty)
       .map(_.items().get(0).get("page").n().toInt + 1)
       .getOrElse(1)
 

--- a/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
@@ -42,41 +42,47 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
   }
 
   private val TtlDays = 7L
+  private val MetaPage = 0
 
   def save(username: String, plays: List[PlayData]): Unit =
     val now = clock()
     val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
-    val item = Map(
-      "username" -> AttributeValue.fromS(username.toLowerCase),
-      "data" -> AttributeValue.fromS(plays.asJson.noSpaces),
-      "cached_at" -> AttributeValue.fromN(now.getEpochSecond.toString),
-      "ttl" -> AttributeValue.fromN(ttl.toString)
-    ).asJava
-
-    val request = PutItemRequest.builder().tableName(tableName).item(item).build()
-    try
-      client.putItem(request)
-      logger.debug(s"Cached ${plays.size} plays for $username")
-    catch
-      case e: Exception =>
-        logger.error(s"Error saving plays for $username", e)
+    deleteAllPages(username)
+    val maxId = plays.map(_.playId).maxOption.getOrElse(0)
+    putPage(username, MetaPage, plays, now, ttl, maxId)
 
   def load(username: String): Option[List[PlayData]] =
-    val request = GetItemRequest
+    val request = QueryRequest
       .builder()
       .tableName(tableName)
-      .key(Map("username" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .keyConditionExpression("username = :u")
+      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username.toLowerCase)).asJava)
       .build()
 
-    tryAwsCall(client.getItem(request), s"Error loading plays for $username")
-      .filter(_.hasItem)
-      .flatMap(response => decodeJson[List[PlayData]](response.item().get("data").s(), s"plays for $username"))
+    tryAwsCall(client.query(request), s"Error loading plays for $username")
+      .filter(_.hasItems)
+      .map { response =>
+        response
+          .items()
+          .asScala
+          .toList
+          .flatMap { item =>
+            decodeJson[List[PlayData]](item.get("data").s(), s"plays chunk for $username").getOrElse(Nil)
+          }
+          .sortBy(_.playId)(Ordering[Int].reverse)
+      }
+      .filter(_.nonEmpty)
 
   def isFresh(username: String, maxAgeSeconds: Long): Boolean =
     val request = GetItemRequest
       .builder()
       .tableName(tableName)
-      .key(Map("username" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .key(
+        Map(
+          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "page" -> AttributeValue.fromN(MetaPage.toString)
+        ).asJava
+      )
       .projectionExpression("cached_at")
       .build()
 
@@ -88,4 +94,138 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
       .exists { cachedAt =>
         val age = clock().getEpochSecond - cachedAt
         age < maxAgeSeconds
+      }
+
+  def append(username: String, plays: List[PlayData]): Unit =
+    val now = clock()
+    val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
+    val nextPage = nextPageNumber(username)
+    putPage(username, nextPage, plays, now, ttl)
+    plays.map(_.playId).maxOption.foreach(updateMaxPlayId(username, _))
+
+  def maxPlayId(username: String): Option[Int] =
+    val request = GetItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(
+        Map(
+          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "page" -> AttributeValue.fromN(MetaPage.toString)
+        ).asJava
+      )
+      .projectionExpression("max_play_id")
+      .build()
+
+    tryAwsCall(client.getItem(request), s"Error getting maxPlayId for $username")
+      .filter(_.hasItem)
+      .flatMap(r => Option(r.item().get("max_play_id")))
+      .map(_.n().toInt)
+      .filter(_ > 0)
+
+  def touch(username: String): Unit =
+    val now = clock()
+    val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
+    val request = UpdateItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(
+        Map(
+          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "page" -> AttributeValue.fromN(MetaPage.toString)
+        ).asJava
+      )
+      .updateExpression("SET cached_at = :now, #t = :ttl")
+      .expressionAttributeNames(Map("#t" -> "ttl").asJava)
+      .expressionAttributeValues(
+        Map(
+          ":now" -> AttributeValue.fromN(now.getEpochSecond.toString),
+          ":ttl" -> AttributeValue.fromN(ttl.toString)
+        ).asJava
+      )
+      .build()
+    try client.updateItem(request): Unit
+    catch case e: Exception => logger.warn(s"Error touching freshness for $username", e)
+
+  private def putPage(username: String, page: Int, plays: List[PlayData], now: Instant, ttl: Long, maxId: Int = 0): Unit =
+    val baseItem = Map(
+      "username" -> AttributeValue.fromS(username.toLowerCase),
+      "page" -> AttributeValue.fromN(page.toString),
+      "data" -> AttributeValue.fromS(plays.asJson.noSpaces),
+      "cached_at" -> AttributeValue.fromN(now.getEpochSecond.toString),
+      "ttl" -> AttributeValue.fromN(ttl.toString)
+    )
+    val item = if maxId > 0 then baseItem + ("max_play_id" -> AttributeValue.fromN(maxId.toString))
+    else baseItem
+
+    val request = PutItemRequest.builder().tableName(tableName).item(item.asJava).build()
+    try
+      client.putItem(request)
+      logger.debug(s"Cached ${plays.size} plays for $username (page $page)")
+    catch
+      case e: Exception =>
+        logger.error(s"Error saving plays for $username page $page", e)
+
+  private def updateMaxPlayId(username: String, newMaxId: Int): Unit =
+    val request = UpdateItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(
+        Map(
+          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "page" -> AttributeValue.fromN(MetaPage.toString)
+        ).asJava
+      )
+      .updateExpression("SET max_play_id = :newMax")
+      .conditionExpression("attribute_not_exists(max_play_id) OR max_play_id < :newMax")
+      .expressionAttributeValues(Map(":newMax" -> AttributeValue.fromN(newMaxId.toString)).asJava)
+      .build()
+    try client.updateItem(request): Unit
+    catch
+      case _: ConditionalCheckFailedException => ()
+      case e: Exception => logger.warn(s"Error updating maxPlayId for $username", e)
+
+  private def nextPageNumber(username: String): Int =
+    val request = QueryRequest
+      .builder()
+      .tableName(tableName)
+      .keyConditionExpression("username = :u")
+      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .projectionExpression("#p")
+      .expressionAttributeNames(Map("#p" -> "page").asJava)
+      .scanIndexForward(false)
+      .limit(1)
+      .build()
+
+    tryAwsCall(client.query(request), s"Error getting next page for $username")
+      .filter(_.hasItems)
+      .map(_.items().get(0).get("page").n().toInt + 1)
+      .getOrElse(1)
+
+  private def deleteAllPages(username: String): Unit =
+    val request = QueryRequest
+      .builder()
+      .tableName(tableName)
+      .keyConditionExpression("username = :u")
+      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .projectionExpression("username, #p")
+      .expressionAttributeNames(Map("#p" -> "page").asJava)
+      .build()
+
+    tryAwsCall(client.query(request), s"Error listing pages for $username")
+      .filter(_.hasItems)
+      .foreach { response =>
+        response.items().asScala.foreach { item =>
+          val deleteReq = DeleteItemRequest
+            .builder()
+            .tableName(tableName)
+            .key(
+              Map(
+                "username" -> item.get("username"),
+                "page" -> item.get("page")
+              ).asJava
+            )
+            .build()
+          try client.deleteItem(deleteReq)
+          catch case e: Exception => logger.warn(s"Error deleting page for $username", e)
+        }
       }

--- a/src/main/scala/bgg/cache/PlaysCache.scala
+++ b/src/main/scala/bgg/cache/PlaysCache.scala
@@ -6,8 +6,14 @@ trait PlaysCache:
   def save(username: String, plays: List[PlayData]): Unit
   def load(username: String): Option[List[PlayData]]
   def isFresh(username: String, maxAgeSeconds: Long): Boolean
+  def append(username: String, plays: List[PlayData]): Unit
+  def maxPlayId(username: String): Option[Int]
+  def touch(username: String): Unit
 
 class NoOpPlaysCache extends PlaysCache:
   def save(username: String, plays: List[PlayData]): Unit = ()
   def load(username: String): Option[List[PlayData]] = None
   def isFresh(username: String, maxAgeSeconds: Long): Boolean = false
+  def append(username: String, plays: List[PlayData]): Unit = ()
+  def maxPlayId(username: String): Option[Int] = None
+  def touch(username: String): Unit = ()

--- a/src/main/scala/bgg/config/AppConfig.scala
+++ b/src/main/scala/bgg/config/AppConfig.scala
@@ -37,7 +37,8 @@ case class AwsConfig(
     dynamoVectorTable: String,
     dynamoPrefetchTable: String,
     dynamoPlaysTable: String,
-    prefetchSqsUrl: String
+    prefetchSqsUrl: String,
+    prefetchStateMachineArn: String
 )
 
 case class ServerConfig(
@@ -82,7 +83,8 @@ object AppConfig:
       dynamoVectorTable = c.getString("aws.dynamoVectorTable"),
       dynamoPrefetchTable = c.getString("aws.dynamoPrefetchTable"),
       dynamoPlaysTable = c.getString("aws.dynamoPlaysTable"),
-      prefetchSqsUrl = c.getString("aws.prefetchSqsUrl")
+      prefetchSqsUrl = c.getString("aws.prefetchSqsUrl"),
+      prefetchStateMachineArn = c.getString("aws.prefetchStateMachineArn")
     )
 
     val server = ServerConfig(

--- a/src/main/scala/bgg/domain/Model.scala
+++ b/src/main/scala/bgg/domain/Model.scala
@@ -23,18 +23,20 @@ object Username:
   extension (u: Username) def value: String = u
 
 enum SourceType:
-  case Collection, GeeKList, Hot
+  case Collection, GeeKList, Hot, Plays
   def toPathSegment: String = this match
     case Collection => "collection"
     case GeeKList   => "geeklist"
     case Hot        => "hot"
+    case Plays      => "plays"
 
 object SourceType:
   def fromString(s: String): Either[String, SourceType] = s.toLowerCase match
     case "collection" => Right(Collection)
     case "geeklist"   => Right(GeeKList)
     case "hot"        => Right(Hot)
-    case other        => Left(s"Invalid source_type '$other'. Must be one of: collection, geeklist, hot")
+    case "plays"      => Right(Plays)
+    case other        => Left(s"Invalid source_type '$other'. Must be one of: collection, geeklist, hot, plays")
 
 // Core game data model — mirrors the Python BoardGame.data() dict shape for cache compatibility
 case class GameData(

--- a/src/main/scala/bgg/lambda/ApiHandler.scala
+++ b/src/main/scala/bgg/lambda/ApiHandler.scala
@@ -4,7 +4,7 @@ import bgg.bggapi.{BggXmlClient, GameService}
 import bgg.cache.{DynamoDbCacheProvider, MemoryCacheProvider, SqliteCacheProvider}
 import bgg.config.{AppConfig, CacheBackend}
 import bgg.prefetch.{DynamoDbPrefetchStatusStore, SqlitePrefetchStatusStore}
-import bgg.routes.{ApiEndpoints, AwsSqsSender, ErrorOutput, NoOpSqsSender}
+import bgg.routes.{ApiEndpoints, StepFunctionsTrigger, ErrorOutput, NoOpPrefetchTrigger, PrefetchTrigger}
 import com.typesafe.scalalogging.StrictLogging
 import ox.*
 import sttp.client4.DefaultSyncBackend
@@ -15,7 +15,7 @@ import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.shared.Identity
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sfn.SfnClient
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 
 import java.time.Instant
@@ -33,7 +33,7 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
     val httpBackend = useInScope(DefaultSyncBackend())(_.close())
     val bggClient = BggXmlClient(config.bgg, httpBackend)
 
-    val (caches, prefetchStore, sqsSender) = config.cache.backend match
+    val (caches, prefetchStore, prefetchTrigger) = config.cache.backend match
       case CacheBackend.DynamoDB =>
         val dynamo = useInScope(
           DynamoDbClient
@@ -42,8 +42,8 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
             .httpClient(UrlConnectionHttpClient.create())
             .build()
         )(_.close())
-        val sqs = useInScope(
-          SqsClient
+        val sfn = useInScope(
+          SfnClient
             .builder()
             .region(Region.of(config.aws.region))
             .httpClient(UrlConnectionHttpClient.create())
@@ -52,25 +52,25 @@ object ApiHandler extends OxApp.Simple with StrictLogging:
         (
           DynamoDbCacheProvider(dynamo, config.aws),
           DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable),
-          AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
+          StepFunctionsTrigger(sfn, config.aws.prefetchStateMachineArn): PrefetchTrigger
         )
 
       case CacheBackend.SQLite =>
         (
           SqliteCacheProvider(config.cache),
           SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
-          NoOpSqsSender()
+          NoOpPrefetchTrigger(): PrefetchTrigger
         )
 
       case CacheBackend.Memory =>
         (
           MemoryCacheProvider(config.cache),
           SqlitePrefetchStatusStore(config.cache.sqlitePrefetchStatusPath),
-          NoOpSqsSender()
+          NoOpPrefetchTrigger(): PrefetchTrigger
         )
 
     val gameService = GameService(bggClient, caches, config.cache.vectorMinRatings, () => Instant.now())
-    ApiEndpoints(gameService, caches.gameCache, caches.vectorStore, prefetchStore, sqsSender, config)
+    ApiEndpoints(gameService, caches.gameCache, caches.vectorStore, prefetchStore, prefetchTrigger, config)
 
   private def startServer(endpoints: ApiEndpoints, config: AppConfig): Unit =
     val serverOptions = NettySyncServerOptions.customiseInterceptors

--- a/src/main/scala/bgg/lambda/ApiLambdaHandler.scala
+++ b/src/main/scala/bgg/lambda/ApiLambdaHandler.scala
@@ -4,12 +4,12 @@ import bgg.bggapi.{BggXmlClient, GameService}
 import bgg.cache.DynamoDbCacheProvider
 import bgg.config.AppConfig
 import bgg.prefetch.DynamoDbPrefetchStatusStore
-import bgg.routes.{ApiEndpoints, AwsSqsSender}
+import bgg.routes.{ApiEndpoints, StepFunctionsTrigger}
 import io.circe.generic.auto.*
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sfn.SfnClient
 import sttp.client4.DefaultSyncBackend
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.serverless.aws.lambda.*
@@ -36,7 +36,7 @@ object ApiLambdaHandler:
       .httpClient(UrlConnectionHttpClient.create())
       .build()
 
-    val sqs = SqsClient
+    val sfn = SfnClient
       .builder()
       .region(Region.of(config.aws.region))
       .httpClient(UrlConnectionHttpClient.create())
@@ -44,7 +44,7 @@ object ApiLambdaHandler:
 
     val caches = DynamoDbCacheProvider(dynamo, config.aws)
     val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
-    val sqsSender = AwsSqsSender(sqs, config.aws.prefetchSqsUrl)
+    val prefetchTrigger = StepFunctionsTrigger(sfn, config.aws.prefetchStateMachineArn)
     val gameService = GameService(bggClient, caches, config.cache.vectorMinRatings, () => Instant.now())
 
-    ApiEndpoints(gameService, caches.gameCache, caches.vectorStore, prefetchStore, sqsSender, config)
+    ApiEndpoints(gameService, caches.gameCache, caches.vectorStore, prefetchStore, prefetchTrigger, config)

--- a/src/main/scala/bgg/lambda/BatchPreparerLogic.scala
+++ b/src/main/scala/bgg/lambda/BatchPreparerLogic.scala
@@ -1,0 +1,44 @@
+package bgg.lambda
+
+import bgg.cache.GameCache
+import bgg.domain.GameId
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.{Json, parser}
+import io.circe.syntax.*
+
+class BatchPreparerLogic(gameCache: GameCache) extends StrictLogging:
+
+  private val ChunkSize = 300
+
+  def handle(eventJson: String): String =
+    val (gameIds, sourceType, sourceId) = parseInput(eventJson)
+    val uncached = filterCached(gameIds)
+    val chunks = uncached.grouped(ChunkSize).toList
+
+    logger.info(s"BatchPreparer: ${gameIds.size} total, ${gameIds.size - uncached.size} cached, " +
+      s"${uncached.size} to fetch in ${chunks.size} chunks")
+
+    val result = chunks.map { chunk =>
+      Json.obj(
+        "gameIds" -> chunk.map(_.value).asJson,
+        "sourceType" -> Json.fromString(sourceType),
+        "sourceId" -> Json.fromString(sourceId)
+      )
+    }
+    Json.fromValues(result).noSpaces
+
+  private def parseInput(json: String): (List[GameId], String, String) =
+    parser.parse(json).toOption
+      .flatMap { j =>
+        for
+          ids <- j.hcursor.downField("gameIds").as[List[Int]].toOption
+          st <- j.hcursor.downField("sourceType").as[String].toOption
+          si <- j.hcursor.downField("sourceId").as[String].toOption
+        yield (ids.map(GameId(_)), st, si)
+      }
+      .getOrElse(throw RuntimeException("Invalid input JSON for BatchPreparer"))
+
+  private def filterCached(ids: List[GameId]): List[GameId] =
+    val cached = gameCache.loadBatch(ids)
+    val cachedIds = cached.map(_.id).toSet
+    ids.filterNot(cachedIds.contains)

--- a/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
@@ -1,21 +1,33 @@
 package bgg.lambda
 
 import bgg.bggapi.BggClient
+import bgg.cache.RequestCache
 import bgg.domain.{Fail, GameId, SourceType}
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.{Json, parser}
 import io.circe.syntax.*
 
+import java.time.Instant
+
 case class CollectionFetchInput(sourceType: String, sourceId: String)
 case class CollectionFetchOutput(gameIds: List[Int], sourceType: String, sourceId: String)
 
-class CollectionFetchLogic(bggClient: BggClient, retries: Int) extends StrictLogging:
+class CollectionFetchLogic(
+    bggClient: BggClient,
+    retries: Int,
+    requestCache: Option[RequestCache] = None,
+    clock: () => Instant = () => Instant.now()
+) extends StrictLogging:
+
+  private val IdsCacheTtlSeconds = 24L * 3600
 
   def handle(eventJson: String): String =
     val result = for
       input <- parseInput(eventJson)
       ids <- fetchIds(input)
-    yield CollectionFetchOutput(ids.map(_.value), input.sourceType, input.sourceId)
+    yield
+      cacheIds(input, ids)
+      CollectionFetchOutput(ids.map(_.value), input.sourceType, input.sourceId)
 
     result match
       case Right(output) =>
@@ -26,6 +38,17 @@ class CollectionFetchLogic(bggClient: BggClient, retries: Int) extends StrictLog
         ).noSpaces
       case Left(fail) =>
         throw toLambdaException(fail)
+
+  private def cacheIds(input: CollectionFetchInput, ids: List[GameId]): Unit =
+    val cacheKey = SourceType.fromString(input.sourceType).toOption match
+      case Some(SourceType.Collection) => Some(s"collection-ids:${input.sourceId}")
+      case Some(SourceType.GeeKList)   => Some(s"geeklist-ids:${input.sourceId}")
+      case _                           => None
+
+    for
+      cache <- requestCache
+      key <- cacheKey
+    do cache.save(key, ids.map(_.value), IdsCacheTtlSeconds, clock())
 
   private def parseInput(json: String): Either[Fail, CollectionFetchInput] =
     parser.parse(json).toOption

--- a/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
@@ -1,0 +1,63 @@
+package bgg.lambda
+
+import bgg.bggapi.BggClient
+import bgg.domain.{Fail, GameId, SourceType}
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.{Json, parser}
+import io.circe.syntax.*
+
+case class CollectionFetchInput(sourceType: String, sourceId: String)
+case class CollectionFetchOutput(gameIds: List[Int], sourceType: String, sourceId: String)
+
+class CollectionFetchLogic(bggClient: BggClient, retries: Int) extends StrictLogging:
+
+  def handle(eventJson: String): String =
+    val result = for
+      input <- parseInput(eventJson)
+      ids <- fetchIds(input)
+    yield CollectionFetchOutput(ids.map(_.value), input.sourceType, input.sourceId)
+
+    result match
+      case Right(output) =>
+        Json.obj(
+          "gameIds" -> output.gameIds.asJson,
+          "sourceType" -> Json.fromString(output.sourceType),
+          "sourceId" -> Json.fromString(output.sourceId)
+        ).noSpaces
+      case Left(fail) =>
+        throw toLambdaException(fail)
+
+  private def parseInput(json: String): Either[Fail, CollectionFetchInput] =
+    parser.parse(json).toOption
+      .flatMap { j =>
+        for
+          st <- j.hcursor.downField("sourceType").as[String].toOption
+          si <- j.hcursor.downField("sourceId").as[String].toOption
+        yield CollectionFetchInput(st, si)
+      }
+      .toRight(Fail.IncorrectInput("Invalid input JSON"))
+
+  private def fetchIds(input: CollectionFetchInput): Either[Fail, List[GameId]] =
+    SourceType.fromString(input.sourceType) match
+      case Left(err) => Left(Fail.IncorrectInput(err))
+      case Right(SourceType.Collection) =>
+        logger.info(s"Fetching collection for ${input.sourceId} with $retries retries")
+        bggClient.fetchCollection(input.sourceId, retries)
+      case Right(SourceType.GeeKList) =>
+        logger.info(s"Fetching geeklist ${input.sourceId}")
+        bggClient.fetchGeeklist(input.sourceId)
+      case Right(SourceType.Hot) =>
+        logger.info(s"Fetching hot games")
+        bggClient.fetchHotGames()
+      case Right(SourceType.Plays) =>
+        Left(Fail.IncorrectInput("Plays is not a valid source type for collection fetch"))
+
+  private def toLambdaException(fail: Fail): RuntimeException = fail match
+    case Fail.BggRateLimited(msg) => BggRateLimitedException(msg)
+    case Fail.BggUserNotFound(u)  => BggUserNotFoundException(s"User not found: $u")
+    case Fail.BggListNotFound(id) => BggListNotFoundException(s"List not found: $id")
+    case other                    => RuntimeException(other.toString)
+
+case class BggRateLimitedException(msg: String) extends RuntimeException(msg)
+case class BggUserNotFoundException(msg: String) extends RuntimeException(msg)
+case class BggListNotFoundException(msg: String) extends RuntimeException(msg)

--- a/src/main/scala/bgg/lambda/GameFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/GameFetchLogic.scala
@@ -1,0 +1,105 @@
+package bgg.lambda
+
+import bgg.bggapi.BggClient
+import bgg.cache.CacheProvider
+import bgg.domain.{Fail, GameData, GameId}
+import bgg.store.StoredVector
+import bgg.vector.VectorMath
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.{Json, parser}
+import io.circe.syntax.*
+import ox.*
+
+import java.time.Instant
+
+case class GameFetchOutput(succeeded: List[Int], failed: List[Int], totalCached: Int)
+
+class GameFetchLogic(
+    bggClient: BggClient,
+    caches: CacheProvider,
+    vectorMinRatings: Int,
+    clock: () => Instant
+) extends StrictLogging:
+
+  private val SubBatchSize = 20
+  private val Parallelism = 5
+
+  def handle(eventJson: String): String =
+    val input = parseInput(eventJson)
+    val output = fetchGames(input)
+    toJson(output)
+
+  private def parseInput(json: String): List[GameId] =
+    parser.parse(json).toOption
+      .flatMap(_.hcursor.downField("gameIds").as[List[Int]].toOption)
+      .map(_.map(GameId(_)))
+      .getOrElse(throw RuntimeException("Invalid input JSON for GameFetch"))
+
+  private def fetchGames(ids: List[GameId]): GameFetchOutput =
+    val (alreadyCached, missing) = partitionCached(ids)
+    logger.info(s"GameFetch: ${ids.size} total, ${alreadyCached.size} already cached, ${missing.size} to fetch")
+
+    if missing.isEmpty then
+      return GameFetchOutput(ids.map(_.value), Nil, alreadyCached.size)
+
+    val subBatches = missing.grouped(SubBatchSize).toList
+    val results = processSubBatchesParallel(subBatches)
+
+    val succeeded = alreadyCached.map(_.id) ++ results.flatMap(_.succeeded)
+    val failed = results.flatMap(_.failed)
+
+    logger.info(s"GameFetch complete: ${succeeded.size} succeeded, ${failed.size} failed")
+    GameFetchOutput(succeeded.map(_.value), failed.map(_.value), succeeded.size)
+
+  private case class SubBatchResult(succeeded: List[GameId], failed: List[GameId])
+
+  private def processSubBatchesParallel(subBatches: List[List[GameId]]): List[SubBatchResult] =
+    supervised:
+      subBatches
+        .grouped(Parallelism)
+        .toList
+        .flatMap { chunk =>
+          val forks = chunk.map { batch =>
+            forkUnsupervised(processSubBatch(batch))
+          }
+          forks.map(_.join())
+        }
+
+  private def processSubBatch(batch: List[GameId]): SubBatchResult =
+    bggClient.fetchGamesByIds(batch) match
+      case Right(games) =>
+        games.foreach(cacheAndSync)
+        val fetchedIds = games.map(_.id).toSet
+        val missed = batch.filterNot(fetchedIds.contains)
+        SubBatchResult(games.map(_.id), missed)
+      case Left(Fail.BggRateLimited(msg)) =>
+        logger.warn(s"Rate limited during sub-batch: $msg")
+        throw BggRateLimitedException(msg)
+      case Left(err) =>
+        logger.error(s"Failed to fetch sub-batch: $err")
+        SubBatchResult(Nil, batch)
+
+  private def partitionCached(ids: List[GameId]): (List[GameData], List[GameId]) =
+    val cached = caches.gameCache.loadBatch(ids)
+    val cachedIds = cached.map(_.id).toSet
+    val missing = ids.filterNot(cachedIds.contains)
+    (cached, missing)
+
+  private def cacheAndSync(game: GameData): Unit =
+    caches.gameCache.save(game, clock())
+    syncVector(game)
+
+  private def syncVector(game: GameData): Unit =
+    val usersRated = game.usersRated.getOrElse(0)
+    if usersRated >= vectorMinRatings then
+      val vector = VectorMath.generateGameVector(game)
+      caches.vectorStore.save(
+        StoredVector(gameId = game.id, name = game.name, vector = vector, updatedAt = clock())
+      )
+
+  private def toJson(output: GameFetchOutput): String =
+    Json.obj(
+      "succeeded" -> output.succeeded.asJson,
+      "failed" -> output.failed.asJson,
+      "totalCached" -> Json.fromInt(output.totalCached)
+    ).noSpaces

--- a/src/main/scala/bgg/lambda/GameFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/GameFetchLogic.scala
@@ -22,7 +22,8 @@ class GameFetchLogic(
 ) extends StrictLogging:
 
   private val SubBatchSize = 20
-  private val Parallelism = 5
+  private val Parallelism = 3
+  private val InterRoundDelayMs = 1000L
 
   def handle(eventJson: String): String =
     val input = parseInput(eventJson)
@@ -55,15 +56,14 @@ class GameFetchLogic(
 
   private def processSubBatchesParallel(subBatches: List[List[GameId]]): List[SubBatchResult] =
     supervised:
-      subBatches
-        .grouped(Parallelism)
-        .toList
-        .flatMap { chunk =>
-          val forks = chunk.map { batch =>
-            forkUnsupervised(processSubBatch(batch))
-          }
-          forks.map(_.join())
+      val rounds = subBatches.grouped(Parallelism).toList
+      rounds.zipWithIndex.flatMap { (chunk, idx) =>
+        if idx > 0 then Thread.sleep(InterRoundDelayMs)
+        val forks = chunk.map { batch =>
+          forkUnsupervised(processSubBatch(batch))
         }
+        forks.map(_.join())
+      }
 
   private def processSubBatch(batch: List[GameId]): SubBatchResult =
     bggClient.fetchGamesByIds(batch) match

--- a/src/main/scala/bgg/lambda/NativeBootstrap.scala
+++ b/src/main/scala/bgg/lambda/NativeBootstrap.scala
@@ -13,9 +13,12 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import sttp.client4.DefaultSyncBackend
 import sttp.tapir.serverless.aws.lambda.*
 
+import java.io.ByteArrayOutputStream
 import java.net.{HttpURLConnection, URI}
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+import java.util.Base64
+import java.util.zip.GZIPOutputStream
 
 object NativeBootstrap:
 
@@ -55,6 +58,10 @@ object NativeBootstrap:
           body = ""
         ).asJson.noSpaces
       else
+        val acceptsGzip = parse(eventJson).toOption
+          .flatMap(_.hcursor.downField("headers").as[Map[String, String]].toOption)
+          .exists(h => h.getOrElse("Accept-Encoding", h.getOrElse("accept-encoding", "")).contains("gzip"))
+
         val response = jsonDecode[AwsRequestV1](eventJson) match
           case Right(v1) => apiRoute(v1.toV2)
           case Left(err) =>
@@ -64,7 +71,13 @@ object NativeBootstrap:
               headers = Map("Content-Type" -> "application/json"),
               body = s"""{"error":"Failed to parse event: ${err.getMessage}"}"""
             )
-        response.copy(headers = response.headers ++ corsHeaders).asJson.noSpaces
+        val withCors = response.copy(headers = response.headers ++ corsHeaders)
+        val isJsonResponse = withCors.headers.get("Content-Type").exists(_.contains("application/json"))
+        val compressed =
+          if acceptsGzip && isJsonResponse && withCors.body.length > 1024 then
+            gzipResponse(withCors)
+          else withCors
+        compressed.asJson.noSpaces
 
   private def buildWorkerRoute(): String => String =
     val worker = PrefetchWorkerLogic.create()
@@ -74,7 +87,12 @@ object NativeBootstrap:
     val config = AppConfig.load()
     val httpBackend = DefaultSyncBackend()
     val bggClient = BggXmlClient(config.bgg, httpBackend)
-    val logic = CollectionFetchLogic(bggClient, config.bgg.retries)
+    val dynamo = DynamoDbClient.builder()
+      .region(Region.of(config.aws.region))
+      .httpClient(UrlConnectionHttpClient.create())
+      .build()
+    val requestCache = bgg.cache.DynamoDbRequestCache(dynamo, config.aws.dynamoRequestTable)
+    val logic = CollectionFetchLogic(bggClient, config.bgg.retries, Some(requestCache))
     eventJson => logic.handle(eventJson)
 
   private def buildPlaysFetchPageRoute(): String => String =
@@ -160,6 +178,20 @@ object NativeBootstrap:
       writeBody(conn, errorBody)
       conn.getResponseCode: Unit
     }
+
+  private def gzipResponse(response: AwsResponse): AwsResponse =
+    val rawBytes =
+      if response.isBase64Encoded then Base64.getDecoder.decode(response.body)
+      else response.body.getBytes(StandardCharsets.UTF_8)
+    val baos = ByteArrayOutputStream()
+    val gzip = GZIPOutputStream(baos)
+    gzip.write(rawBytes)
+    gzip.close()
+    response.copy(
+      isBase64Encoded = true,
+      headers = response.headers + ("Content-Encoding" -> "gzip"),
+      body = Base64.getEncoder.encodeToString(baos.toByteArray)
+    )
 
   private def withConnection[T](url: String, method: String)(f: HttpURLConnection => T): T =
     val conn = URI.create(url).toURL.openConnection().asInstanceOf[HttpURLConnection]

--- a/src/main/scala/bgg/lambda/NativeBootstrap.scala
+++ b/src/main/scala/bgg/lambda/NativeBootstrap.scala
@@ -135,6 +135,7 @@ object NativeBootstrap:
     catch
       case e: Exception =>
         System.err.println(s"[bootstrap] Error processing $requestId: ${e.getMessage}")
+        e.printStackTrace(System.err)
         postError(requestId, e)
     pollLoop()
 

--- a/src/main/scala/bgg/lambda/NativeBootstrap.scala
+++ b/src/main/scala/bgg/lambda/NativeBootstrap.scala
@@ -1,12 +1,21 @@
 package bgg.lambda
 
+import bgg.bggapi.BggXmlClient
+import bgg.cache.DynamoDbCacheProvider
+import bgg.config.AppConfig
+import bgg.prefetch.DynamoDbPrefetchStatusStore
 import io.circe.generic.auto.*
 import io.circe.parser.{decode as jsonDecode, parse}
 import io.circe.syntax.*
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import sttp.client4.DefaultSyncBackend
 import sttp.tapir.serverless.aws.lambda.*
 
 import java.net.{HttpURLConnection, URI}
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 
 object NativeBootstrap:
 
@@ -14,12 +23,17 @@ object NativeBootstrap:
   private lazy val handler = sys.env.getOrElse("LAMBDA_HANDLER", "api")
   private lazy val route = handler match
     case h if h.contains("PrefetchWorker") => buildWorkerRoute()
+    case "CollectionFetch"                 => buildCollectionFetchRoute()
+    case "PlaysFetchPage"                  => buildPlaysFetchPageRoute()
+    case "GameFetch"                       => buildGameFetchRoute()
+    case "BatchPreparer"                   => buildBatchPreparerRoute()
+    case "StatusUpdater"                   => buildStatusUpdaterRoute()
     case _                                 => buildApiRoute()
 
   private val corsHeaders = Map(
     "Access-Control-Allow-Origin" -> "*",
     "Access-Control-Allow-Methods" -> "GET, HEAD, POST, OPTIONS",
-    "Access-Control-Allow-Headers" -> "Content-Type, Bgg-Filter-Player-Count, Bgg-Filter-Using-Recommended-Players, Bgg-Filter-Min-Duration, Bgg-Filter-Max-Duration, Bgg-Filter-Complexity, Bgg-Filter-Min-Rating, Bgg-Filter-Mechanic, Bgg-Include-Expansions, Bgg-Field-Whitelist",
+    "Access-Control-Allow-Headers" -> "Content-Type, Bgg-Filter-Player-Count, Bgg-Filter-Using-Recommended-Players, Bgg-Filter-Min-Duration, Bgg-Filter-Max-Duration, Bgg-Filter-Complexity, Bgg-Filter-Min-Rating, Bgg-Filter-Mechanic, Bgg-Include-Expansions, Bgg-Field-Whitelist, Bgg-Plays-Meta",
     "Access-Control-Max-Age" -> "86400",
     "Vary" -> "Accept-Encoding"
   )
@@ -55,6 +69,58 @@ object NativeBootstrap:
   private def buildWorkerRoute(): String => String =
     val worker = PrefetchWorkerLogic.create()
     eventJson => worker.handleSqsEvent(eventJson)
+
+  private def buildCollectionFetchRoute(): String => String =
+    val config = AppConfig.load()
+    val httpBackend = DefaultSyncBackend()
+    val bggClient = BggXmlClient(config.bgg, httpBackend)
+    val logic = CollectionFetchLogic(bggClient, config.bgg.retries)
+    eventJson => logic.handle(eventJson)
+
+  private def buildPlaysFetchPageRoute(): String => String =
+    val config = AppConfig.load()
+    val httpBackend = DefaultSyncBackend()
+    val bggClient = BggXmlClient(config.bgg, httpBackend)
+    val dynamo = DynamoDbClient.builder()
+      .region(Region.of(config.aws.region))
+      .httpClient(UrlConnectionHttpClient.create())
+      .build()
+    val caches = DynamoDbCacheProvider(dynamo, config.aws)
+    val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
+    val logic = PlaysFetchPageLogic(bggClient, caches.playsCache, prefetchStore)
+    eventJson => logic.handle(eventJson)
+
+  private def buildGameFetchRoute(): String => String =
+    val config = AppConfig.load()
+    val httpBackend = DefaultSyncBackend()
+    val bggClient = BggXmlClient(config.bgg, httpBackend)
+    val dynamo = DynamoDbClient.builder()
+      .region(Region.of(config.aws.region))
+      .httpClient(UrlConnectionHttpClient.create())
+      .build()
+    val caches = DynamoDbCacheProvider(dynamo, config.aws)
+    val logic = GameFetchLogic(bggClient, caches, config.cache.vectorMinRatings, () => Instant.now())
+    eventJson => logic.handle(eventJson)
+
+  private def buildBatchPreparerRoute(): String => String =
+    val config = AppConfig.load()
+    val dynamo = DynamoDbClient.builder()
+      .region(Region.of(config.aws.region))
+      .httpClient(UrlConnectionHttpClient.create())
+      .build()
+    val caches = DynamoDbCacheProvider(dynamo, config.aws)
+    val logic = BatchPreparerLogic(caches.gameCache)
+    eventJson => logic.handle(eventJson)
+
+  private def buildStatusUpdaterRoute(): String => String =
+    val config = AppConfig.load()
+    val dynamo = DynamoDbClient.builder()
+      .region(Region.of(config.aws.region))
+      .httpClient(UrlConnectionHttpClient.create())
+      .build()
+    val prefetchStore = DynamoDbPrefetchStatusStore(dynamo, config.aws.dynamoPrefetchTable)
+    val logic = StatusUpdaterLogic(prefetchStore)
+    eventJson => logic.handle(eventJson)
 
   def main(args: Array[String]): Unit =
     System.err.println(s"[bootstrap] Starting handler=$handler")

--- a/src/main/scala/bgg/lambda/PlaysFetchPageLogic.scala
+++ b/src/main/scala/bgg/lambda/PlaysFetchPageLogic.scala
@@ -1,0 +1,150 @@
+package bgg.lambda
+
+import bgg.bggapi.BggClient
+import bgg.cache.PlaysCache
+import bgg.domain.SourceType
+import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore}
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.{Json, parser}
+
+case class PlaysFetchPageInput(username: String, page: Int, sourceType: String, sourceId: String, cachedMaxPlayId: Option[Int])
+case class PlaysFetchPageOutput(nextPage: Int, done: Boolean, totalSoFar: Int, username: String, sourceType: String, sourceId: String, cachedMaxPlayId: Option[Int])
+
+class PlaysFetchPageLogic(
+    bggClient: BggClient,
+    playsCache: PlaysCache,
+    prefetchStore: PrefetchStatusStore,
+    playsCacheTtlSeconds: Long = 24L * 3600
+) extends StrictLogging:
+
+  def handle(eventJson: String): String =
+    val input = parseInput(eventJson)
+    val result = fetchPage(input)
+    toJson(result)
+
+  private def parseInput(json: String): PlaysFetchPageInput =
+    parser.parse(json).toOption
+      .flatMap { j =>
+        for
+          username <- j.hcursor.downField("username").as[String].toOption
+          page <- j.hcursor.downField("page").as[Int].toOption
+          st <- j.hcursor.downField("sourceType").as[String].toOption
+          si <- j.hcursor.downField("sourceId").as[String].toOption
+        yield
+          val cachedMax = j.hcursor.downField("cachedMaxPlayId").as[Int].toOption
+          PlaysFetchPageInput(username, page, st, si, cachedMax)
+      }
+      .getOrElse(throw RuntimeException("Invalid input JSON for PlaysFetchPage"))
+
+  private def fetchPage(input: PlaysFetchPageInput): PlaysFetchPageOutput =
+    if input.page == 1 && playsCache.isFresh(input.username, playsCacheTtlSeconds) then
+      val total = countTotal(input.username)
+      logger.info(s"Plays cache for ${input.username} is fresh ($total plays), skipping fetch")
+      prefetchStore.set(SourceType.Plays, input.username, PrefetchStatus.Completed)
+      return PlaysFetchPageOutput(
+        nextPage = input.page,
+        done = true,
+        totalSoFar = total,
+        username = input.username,
+        sourceType = input.sourceType,
+        sourceId = input.sourceId,
+        cachedMaxPlayId = input.cachedMaxPlayId
+      )
+
+    val cachedMaxPlayId = if input.page == 1 then
+      val maxId = playsCache.maxPlayId(input.username)
+      prefetchStore.set(SourceType.Plays, input.username, PrefetchStatus.Processing)
+      maxId
+    else
+      input.cachedMaxPlayId
+
+    bggClient.fetchPlays(input.username, input.page) match
+      case Right(plays) if plays.nonEmpty =>
+        val (newPlays, hitCached) = cachedMaxPlayId match
+          case Some(maxId) =>
+            val fresh = plays.takeWhile(_.playId > maxId)
+            (fresh, fresh.size < plays.size)
+          case None =>
+            (plays, false)
+
+        if newPlays.nonEmpty then
+          playsCache.append(input.username, newPlays)
+
+        if hitCached then
+          markPlaysComplete(input.username)
+          val total = countTotal(input.username)
+          logger.info(s"Caught up to cached plays for ${input.username} on page ${input.page} ($total total)")
+          PlaysFetchPageOutput(
+            nextPage = input.page,
+            done = true,
+            totalSoFar = total,
+            username = input.username,
+            sourceType = input.sourceType,
+            sourceId = input.sourceId,
+            cachedMaxPlayId = cachedMaxPlayId
+          )
+        else
+          updatePagesFetched(input.username, input.page)
+          val total = countTotal(input.username)
+          logger.info(s"Fetched page ${input.page} for ${input.username}: ${newPlays.size} plays (total: $total)")
+          PlaysFetchPageOutput(
+            nextPage = input.page + 1,
+            done = false,
+            totalSoFar = total,
+            username = input.username,
+            sourceType = input.sourceType,
+            sourceId = input.sourceId,
+            cachedMaxPlayId = cachedMaxPlayId
+          )
+
+      case Right(_) =>
+        markPlaysComplete(input.username)
+        val total = countTotal(input.username)
+        logger.info(s"Plays fetch complete for ${input.username} after ${input.page - 1} pages ($total plays)")
+        PlaysFetchPageOutput(
+          nextPage = input.page,
+          done = true,
+          totalSoFar = total,
+          username = input.username,
+          sourceType = input.sourceType,
+          sourceId = input.sourceId,
+          cachedMaxPlayId = cachedMaxPlayId
+        )
+
+      case Left(err) if input.page == 1 =>
+        throw BggRateLimitedException(s"Failed to fetch first page of plays: $err")
+
+      case Left(err) =>
+        logger.warn(s"Error on page ${input.page} for ${input.username}: $err, finishing with what we have")
+        markPlaysComplete(input.username)
+        val total = countTotal(input.username)
+        PlaysFetchPageOutput(
+          nextPage = input.page,
+          done = true,
+          totalSoFar = total,
+          username = input.username,
+          sourceType = input.sourceType,
+          sourceId = input.sourceId,
+          cachedMaxPlayId = cachedMaxPlayId
+        )
+
+  private def markPlaysComplete(username: String): Unit =
+    playsCache.touch(username)
+    prefetchStore.set(SourceType.Plays, username, PrefetchStatus.Completed)
+
+  private def updatePagesFetched(username: String, page: Int): Unit =
+    prefetchStore.set(SourceType.Plays, username, PrefetchStatus.Processing, s"page:$page")
+
+  private def countTotal(username: String): Int =
+    playsCache.load(username).map(_.size).getOrElse(0)
+
+  private def toJson(output: PlaysFetchPageOutput): String =
+    Json.obj(
+      "nextPage" -> Json.fromInt(output.nextPage),
+      "done" -> Json.fromBoolean(output.done),
+      "totalSoFar" -> Json.fromInt(output.totalSoFar),
+      "username" -> Json.fromString(output.username),
+      "sourceType" -> Json.fromString(output.sourceType),
+      "sourceId" -> Json.fromString(output.sourceId),
+      "cachedMaxPlayId" -> output.cachedMaxPlayId.fold(Json.fromInt(0))(Json.fromInt)
+    ).noSpaces

--- a/src/main/scala/bgg/lambda/PrefetchWorker.scala
+++ b/src/main/scala/bgg/lambda/PrefetchWorker.scala
@@ -89,6 +89,7 @@ class PrefetchWorkerLogic(
             collectionResult
           case SourceType.GeeKList => gameService.resolveGeeklist(msg.sourceId)
           case SourceType.Hot      => gameService.resolveHotGames()
+          case SourceType.Plays    => Right(Nil)
 
         result match
           case Right(_) =>

--- a/src/main/scala/bgg/lambda/StatusUpdaterLogic.scala
+++ b/src/main/scala/bgg/lambda/StatusUpdaterLogic.scala
@@ -1,0 +1,31 @@
+package bgg.lambda
+
+import bgg.domain.SourceType
+import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore}
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.parser
+
+class StatusUpdaterLogic(prefetchStore: PrefetchStatusStore) extends StrictLogging:
+
+  def handle(eventJson: String): String =
+    val (sourceType, sourceId, status, reason) = parseInput(eventJson)
+    prefetchStore.set(sourceType, sourceId, status, reason)
+    logger.info(s"Updated status: ${sourceType.toPathSegment}:$sourceId -> ${status.dbKey}")
+    """{"ok":true}"""
+
+  private def parseInput(json: String): (SourceType, String, PrefetchStatus, String) =
+    parser.parse(json).toOption
+      .flatMap { j =>
+        for
+          st <- j.hcursor.downField("sourceType").as[String].toOption
+          si <- j.hcursor.downField("sourceId").as[String].toOption
+          status <- j.hcursor.downField("status").as[String].toOption
+        yield
+          val reason = j.hcursor.downField("reason").as[String].getOrElse("")
+          val sourceType = SourceType.fromString(st).getOrElse(
+            throw RuntimeException(s"Invalid sourceType: $st")
+          )
+          val prefetchStatus = PrefetchStatus.fromDbKey(status)
+          (sourceType, si, prefetchStatus, reason)
+      }
+      .getOrElse(throw RuntimeException("Invalid input JSON for StatusUpdater"))

--- a/src/main/scala/bgg/routes/ApiEndpoints.scala
+++ b/src/main/scala/bgg/routes/ApiEndpoints.scala
@@ -44,7 +44,7 @@ class ApiEndpoints(
     gameCache: GameCache,
     vectorStore: VectorStore,
     prefetchStore: PrefetchStatusStore,
-    sqsSender: SqsSender,
+    prefetchTrigger: PrefetchTrigger,
     config: AppConfig
 ) extends StrictLogging:
 
@@ -122,10 +122,12 @@ class ApiEndpoints(
   // GET /plays/:username
   val playsEndpoint = baseEndpoint.get
     .in("plays" / path[String]("username"))
-    .out(jsonBody[List[Json]])
-    .handle { username =>
+    .in(headers)
+    .out(jsonBody[Json])
+    .handle { (username, hdrs) =>
+      val includeMeta = hdrs.exists(_.name.equalsIgnoreCase("Bgg-Plays-Meta"))
       gameService.resolvePlays(username).map { plays =>
-        plays.groupBy(_.gameId).toList.map { (gameId, gamePlays) =>
+        val groupedPlays = plays.groupBy(_.gameId).toList.map { (gameId, gamePlays) =>
           val totalPlays = gamePlays.map(_.quantity).sum
           val playsArray = Json.fromValues(gamePlays.map { p =>
             Json.obj(
@@ -149,8 +151,27 @@ class ApiEndpoints(
             "plays" -> playsArray
           )
         }
+        if includeMeta then
+          Json.obj(
+            "plays" -> Json.fromValues(groupedPlays),
+            "meta" -> playsMetadata(username)
+          )
+        else
+          Json.fromValues(groupedPlays)
       }
     }
+
+  private def playsMetadata(username: String): Json =
+    prefetchStore.get(SourceType.Plays, username) match
+      case Some(record) if record.status == PrefetchStatus.Processing =>
+        val pagesFetched = record.reason.stripPrefix("page:").toIntOption.getOrElse(0)
+        Json.obj(
+          "complete" -> Json.fromBoolean(false),
+          "pages_fetched" -> Json.fromInt(pagesFetched),
+          "retry_after_seconds" -> Json.fromInt(30)
+        )
+      case _ =>
+        Json.obj("complete" -> Json.fromBoolean(true))
 
   // GET /search/:query
   val searchEndpoint = baseEndpoint.get
@@ -175,7 +196,7 @@ class ApiEndpoints(
             val status = prefetchStore.get(sourceType, sourceId).map(_.status.dbKey).getOrElse("pending")
             Right((StatusCode.Ok, PrefetchResponse(status, "Already queued or recently completed")))
           else
-            sqsSender.send(sourceType, sourceId)
+            prefetchTrigger.trigger(sourceType, sourceId)
             prefetchStore.set(sourceType, sourceId, PrefetchStatus.Pending)
             Right((StatusCode.Accepted, PrefetchResponse("pending", "Queued for prefetch")))
     }

--- a/src/main/scala/bgg/routes/PrefetchTrigger.scala
+++ b/src/main/scala/bgg/routes/PrefetchTrigger.scala
@@ -17,7 +17,8 @@ class StepFunctionsTrigger(sfnClient: SfnClient, stateMachineArn: String) extend
       "sourceType" -> Json.fromString(sourceType.toPathSegment),
       "sourceId" -> Json.fromString(sourceId)
     ).noSpaces
-    val name = s"${sourceType.toPathSegment}-${sourceId}-${Instant.now().toEpochMilli}"
+    val sanitizedId = sourceId.replaceAll("[^a-zA-Z0-9_-]", "_")
+    val name = s"${sourceType.toPathSegment}-${sanitizedId}-${Instant.now().toEpochMilli}"
     sfnClient.startExecution(
       StartExecutionRequest.builder()
         .stateMachineArn(stateMachineArn)

--- a/src/main/scala/bgg/routes/PrefetchTrigger.scala
+++ b/src/main/scala/bgg/routes/PrefetchTrigger.scala
@@ -1,0 +1,31 @@
+package bgg.routes
+
+import bgg.domain.SourceType
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.Json
+import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sfn.model.StartExecutionRequest
+
+import java.time.Instant
+
+trait PrefetchTrigger:
+  def trigger(sourceType: SourceType, sourceId: String): Unit
+
+class StepFunctionsTrigger(sfnClient: SfnClient, stateMachineArn: String) extends PrefetchTrigger with StrictLogging:
+  def trigger(sourceType: SourceType, sourceId: String): Unit =
+    val input = Json.obj(
+      "sourceType" -> Json.fromString(sourceType.toPathSegment),
+      "sourceId" -> Json.fromString(sourceId)
+    ).noSpaces
+    val name = s"${sourceType.toPathSegment}-${sourceId}-${Instant.now().toEpochMilli}"
+    sfnClient.startExecution(
+      StartExecutionRequest.builder()
+        .stateMachineArn(stateMachineArn)
+        .name(name)
+        .input(input)
+        .build()
+    )
+    logger.debug(s"Started Step Functions execution for ${sourceType.toPathSegment}/$sourceId")
+
+class NoOpPrefetchTrigger extends PrefetchTrigger:
+  def trigger(sourceType: SourceType, sourceId: String): Unit = ()

--- a/src/test/scala/bgg/TestFixtures.scala
+++ b/src/test/scala/bgg/TestFixtures.scala
@@ -31,7 +31,7 @@ object TestFixtures:
       gamesResult: Either[Fail, List[GameData]] = Right(Nil),
       playsResult: Either[Fail, List[PlayData]] = Right(Nil)
   ): BggClient = new BggClient:
-    def fetchCollection(username: String): Either[Fail, List[GameId]] = collectionResult
+    def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = collectionResult
     def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
     def fetchHotGames(): Either[Fail, List[GameId]] = hotResult
     def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult
@@ -57,7 +57,8 @@ object TestFixtures:
       dynamoVectorTable = "",
       dynamoPrefetchTable = "",
       dynamoPlaysTable = "",
-      prefetchSqsUrl = ""
+      prefetchSqsUrl = "",
+      prefetchStateMachineArn = ""
     ),
     server = ServerConfig(host = "0.0.0.0", port = 8080, allowedOrigins = List("*"))
   )

--- a/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
+++ b/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
@@ -206,13 +206,13 @@ class BggXmlClientSpec extends AnyWordSpec with Matchers:
       capturedUrl should include("id=100,200,300")
       capturedUrl should include("stats=1")
 
-    "return empty list on failure for a batch" in:
+    "propagate rate limit error after retries exhausted" in:
       val backend = stubBackend(statusCode = StatusCode.TooManyRequests)
-      val client = BggXmlClient(defaultConfig.copy(retries = 1), backend)
+      val client = BggXmlClient(defaultConfig.copy(retries = 1, retryDelaySeconds = 0), backend)
 
       val result = client.fetchGamesByIds(List(GameId(1)))
 
-      result shouldBe Right(Nil)
+      result shouldBe Left(Fail.BggRateLimited("BGG rate limit exceeded after retries"))
 
   "fetchHotGames" should:
     "parse game IDs from hot games XML" in:

--- a/src/test/scala/bgg/bggapi/GameServiceSpec.scala
+++ b/src/test/scala/bgg/bggapi/GameServiceSpec.scala
@@ -32,6 +32,10 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     def save(username: String, plays: List[PlayData]): Unit = store(username) = plays
     def load(username: String): Option[List[PlayData]] = store.get(username)
     def isFresh(username: String, maxAgeSeconds: Long): Boolean = fresh && store.contains(username)
+    def append(username: String, plays: List[PlayData]): Unit =
+      store(username) = store.getOrElse(username, Nil) ++ plays
+    def maxPlayId(username: String): Option[Int] = store.get(username).flatMap(_.map(_.playId).maxOption)
+    def touch(username: String): Unit = ()
 
   private class MemoryRequestCache extends RequestCache:
     private val store: mutable.Map[String, String] = mutable.Map.empty
@@ -53,7 +57,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
   private def stubClient(
       playsPage1: Either[Fail, List[PlayData]] = Right(Nil)
   ): BggClient = new BggClient:
-    def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+    def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
     def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
     def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
     def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -96,7 +100,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "paginate until empty page" in:
       var pageRequests = List.empty[Int]
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -119,7 +123,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "stop pagination on error after first page" in:
       var pageRequests = List.empty[Int]
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -151,7 +155,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "skip fetch when cache is fresh" in:
       var fetchCount = 0
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -182,7 +186,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "cache result in request cache and serve from cache on second call" in:
       var fetchCount = 0
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] =
           fetchCount += 1
@@ -206,7 +210,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "vectorize a mature game with enough ratings" in:
       val matureGame = testGame(1, "Old Classic").copy(yearPublished = Some(2010), usersRated = Some(1000))
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(matureGame))
@@ -223,7 +227,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "not vectorize a mature game with too few ratings" in:
       val lowRated = testGame(2, "Obscure").copy(yearPublished = Some(2010), usersRated = Some(5))
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(lowRated))
@@ -241,7 +245,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       val currentYear = java.time.Year.now(java.time.ZoneOffset.UTC).getValue
       val newGame = testGame(3, "Brand New").copy(yearPublished = Some(currentYear), usersRated = Some(15))
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(newGame))
@@ -259,7 +263,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       val currentYear = java.time.Year.now(java.time.ZoneOffset.UTC).getValue
       val tooNew = testGame(4, "Too New").copy(yearPublished = Some(currentYear), usersRated = Some(3))
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(tooNew))

--- a/src/test/scala/bgg/lambda/ApiLambdaHandlerSpec.scala
+++ b/src/test/scala/bgg/lambda/ApiLambdaHandlerSpec.scala
@@ -5,7 +5,7 @@ import bgg.bggapi.{BggClient, GameService}
 import bgg.cache.{MemoryGameCache, TestCacheProvider}
 import bgg.domain.*
 import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
-import bgg.routes.{ApiEndpoints, NoOpSqsSender}
+import bgg.routes.{ApiEndpoints, NoOpPrefetchTrigger}
 import bgg.store.{SqliteVectorStore, StoredVector}
 import bgg.vector.VectorMath
 import io.circe.generic.auto.*
@@ -43,7 +43,7 @@ class ApiLambdaHandlerSpec extends AnyWordSpec with Matchers with BeforeAndAfter
 
   private def makeHandler(bggClient: BggClient): SyncLambdaHandler[AwsRequestV1] =
     val gameService = GameService(bggClient, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
-    val endpoints = ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig)
+    val endpoints = ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpPrefetchTrigger(), testConfig)
     SyncLambdaHandler(endpoints.all, AwsSyncServerOptions.default)
 
   private def sendEvent(handler: SyncLambdaHandler[AwsRequestV1], eventJson: String): (Int, Json) =

--- a/src/test/scala/bgg/lambda/BatchPreparerLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/BatchPreparerLogicSpec.scala
@@ -1,0 +1,62 @@
+package bgg.lambda
+
+import bgg.TestFixtures.testGame
+import bgg.cache.MemoryGameCache
+import bgg.domain.GameId
+import io.circe.parser.parse
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+class BatchPreparerLogicSpec extends AnyWordSpec with Matchers:
+
+  "BatchPreparerLogic" should:
+
+    "split IDs into chunks of 300" in:
+      val gameCache = MemoryGameCache()
+      val logic = BatchPreparerLogic(gameCache)
+      val ids = (1 to 650).toList
+      val input = s"""{"gameIds":${ids.mkString("[",",","]")},"sourceType":"collection","sourceId":"test"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      val batches = result.asArray.get
+      batches should have size 3
+      batches(0).hcursor.downField("gameIds").as[List[Int]].toOption.get should have size 300
+      batches(1).hcursor.downField("gameIds").as[List[Int]].toOption.get should have size 300
+      batches(2).hcursor.downField("gameIds").as[List[Int]].toOption.get should have size 50
+
+    "filter out already-cached IDs" in:
+      val gameCache = MemoryGameCache()
+      gameCache.save(testGame(1, "Catan"), Instant.now())
+      gameCache.save(testGame(2, "Pandemic"), Instant.now())
+
+      val logic = BatchPreparerLogic(gameCache)
+      val input = """{"gameIds":[1,2,3,4,5],"sourceType":"collection","sourceId":"test"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      val batches = result.asArray.get
+      batches should have size 1
+      val ids = batches(0).hcursor.downField("gameIds").as[List[Int]].toOption.get
+      ids shouldBe List(3, 4, 5)
+
+    "return empty array when all games are cached" in:
+      val gameCache = MemoryGameCache()
+      gameCache.save(testGame(1, "Catan"), Instant.now())
+      gameCache.save(testGame(2, "Pandemic"), Instant.now())
+
+      val logic = BatchPreparerLogic(gameCache)
+      val input = """{"gameIds":[1,2],"sourceType":"collection","sourceId":"test"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      result.asArray.get shouldBe empty
+
+    "preserve sourceType and sourceId in each batch" in:
+      val gameCache = MemoryGameCache()
+      val logic = BatchPreparerLogic(gameCache)
+      val input = """{"gameIds":[1,2,3],"sourceType":"geeklist","sourceId":"12345"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      val batch = result.asArray.get.head
+      batch.hcursor.downField("sourceType").as[String].toOption.get shouldBe "geeklist"
+      batch.hcursor.downField("sourceId").as[String].toOption.get shouldBe "12345"

--- a/src/test/scala/bgg/lambda/CollectionFetchLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/CollectionFetchLogicSpec.scala
@@ -1,0 +1,72 @@
+package bgg.lambda
+
+import bgg.TestFixtures.{stubClient, testGame}
+import bgg.bggapi.BggClient
+import bgg.domain.*
+import io.circe.parser.parse
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CollectionFetchLogicSpec extends AnyWordSpec with Matchers:
+
+  "CollectionFetchLogic" should:
+
+    "return game IDs for a valid collection" in:
+      val client = stubClient(collectionResult = Right(List(GameId(1), GameId(2), GameId(3))))
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"collection","sourceId":"testuser"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      val ids = result.hcursor.downField("gameIds").as[List[Int]].toOption.get
+      ids shouldBe List(1, 2, 3)
+      result.hcursor.downField("sourceType").as[String].toOption.get shouldBe "collection"
+      result.hcursor.downField("sourceId").as[String].toOption.get shouldBe "testuser"
+
+    "return game IDs for a geeklist" in:
+      val client = stubClient(geeklistResult = Right(List(GameId(10), GameId(20))))
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"geeklist","sourceId":"12345"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      val ids = result.hcursor.downField("gameIds").as[List[Int]].toOption.get
+      ids shouldBe List(10, 20)
+
+    "return game IDs for hot games" in:
+      val client = stubClient(hotResult = Right(List(GameId(100))))
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"hot","sourceId":"trending"}"""
+
+      val result = parse(logic.handle(input)).toOption.get
+      val ids = result.hcursor.downField("gameIds").as[List[Int]].toOption.get
+      ids shouldBe List(100)
+
+    "throw BggRateLimitedException on rate limit" in:
+      val client = stubClient(collectionResult = Left(Fail.BggRateLimited("Too many")))
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"collection","sourceId":"testuser"}"""
+
+      val ex = intercept[BggRateLimitedException](logic.handle(input))
+      ex.getMessage should include("Too many")
+
+    "throw BggUserNotFoundException when user not found" in:
+      val client = stubClient(collectionResult = Left(Fail.BggUserNotFound("ghost")))
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"collection","sourceId":"ghost"}"""
+
+      val ex = intercept[BggUserNotFoundException](logic.handle(input))
+      ex.getMessage should include("ghost")
+
+    "throw BggListNotFoundException when list not found" in:
+      val client = stubClient(geeklistResult = Left(Fail.BggListNotFound("99999")))
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"geeklist","sourceId":"99999"}"""
+
+      val ex = intercept[BggListNotFoundException](logic.handle(input))
+      ex.getMessage should include("99999")
+
+    "throw on invalid source type" in:
+      val client = stubClient()
+      val logic = CollectionFetchLogic(client, retries = 6)
+      val input = """{"sourceType":"invalid","sourceId":"test"}"""
+
+      intercept[RuntimeException](logic.handle(input))

--- a/src/test/scala/bgg/lambda/GameFetchLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/GameFetchLogicSpec.scala
@@ -1,0 +1,127 @@
+package bgg.lambda
+
+import bgg.TestFixtures.testGame
+import bgg.bggapi.BggClient
+import bgg.cache.{GameCache, MemoryGameCache, TestCacheProvider}
+import bgg.domain.*
+import bgg.store.SqliteVectorStore
+import io.circe.parser.parse
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Files, Paths}
+import java.time.Instant
+
+class GameFetchLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
+
+  private val vectorDb = "test_game_fetch_vectors.sqlite"
+  private var vectorStore: SqliteVectorStore = _
+  private var gameCache: MemoryGameCache = _
+
+  override def beforeEach(): Unit =
+    Files.deleteIfExists(Paths.get(vectorDb)): Unit
+    vectorStore = SqliteVectorStore(vectorDb)
+    gameCache = MemoryGameCache()
+
+  override def afterEach(): Unit =
+    vectorStore.close()
+    Files.deleteIfExists(Paths.get(vectorDb)): Unit
+
+  private def makeLogic(client: BggClient): GameFetchLogic =
+    val caches = TestCacheProvider(gameCache, vectorStore)
+    GameFetchLogic(client, caches, 50, () => Instant.now())
+
+  "GameFetchLogic" should:
+
+    "fetch games and return succeeded IDs" in:
+      val games = List(testGame(1, "Catan"), testGame(2, "Pandemic"))
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(games.filter(g => ids.contains(g.id)))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val logic = makeLogic(client)
+      val input = """{"gameIds":[1,2]}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      val succeeded = result.hcursor.downField("succeeded").as[List[Int]].toOption.get
+      succeeded should contain allOf (1, 2)
+      result.hcursor.downField("totalCached").as[Int].toOption.get shouldBe 2
+
+    "skip already-cached games" in:
+      val game1 = testGame(1, "Catan")
+      gameCache.save(game1, Instant.now())
+
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
+          ids should not contain GameId(1)
+          Right(List(testGame(2, "Pandemic")))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val logic = makeLogic(client)
+      val input = """{"gameIds":[1,2]}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      val succeeded = result.hcursor.downField("succeeded").as[List[Int]].toOption.get
+      succeeded should contain allOf (1, 2)
+
+    "report failed sub-batches" in:
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
+          Left(Fail.IncorrectInput("BGG error"))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val logic = makeLogic(client)
+      val input = """{"gameIds":[1,2,3]}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      val failed = result.hcursor.downField("failed").as[List[Int]].toOption.get
+      failed should contain allOf (1, 2, 3)
+
+    "throw BggRateLimitedException on rate limit" in:
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
+          Left(Fail.BggRateLimited("rate limited"))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val logic = makeLogic(client)
+      val input = """{"gameIds":[1,2,3]}"""
+
+      intercept[BggRateLimitedException](logic.handle(input))
+
+    "return all as succeeded when all are already cached" in:
+      gameCache.save(testGame(1, "Catan"), Instant.now())
+      gameCache.save(testGame(2, "Pandemic"), Instant.now())
+
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
+          fail("Should not be called when all games are cached")
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val logic = makeLogic(client)
+      val input = """{"gameIds":[1,2]}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      val succeeded = result.hcursor.downField("succeeded").as[List[Int]].toOption.get
+      succeeded should contain allOf (1, 2)
+      result.hcursor.downField("failed").as[List[Int]].toOption.get shouldBe empty

--- a/src/test/scala/bgg/lambda/PlaysFetchPageLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/PlaysFetchPageLogicSpec.scala
@@ -1,0 +1,191 @@
+package bgg.lambda
+
+import bgg.TestFixtures.stubClient
+import bgg.bggapi.BggClient
+import bgg.cache.{NoOpPlaysCache, PlaysCache}
+import bgg.domain.*
+import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore, SqlitePrefetchStatusStore}
+import io.circe.parser.parse
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Files, Paths}
+import scala.collection.mutable
+
+class PlaysFetchPageLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
+
+  private val prefetchDb = "test_plays_fetch_prefetch.sqlite"
+  private var prefetchStore: SqlitePrefetchStatusStore = _
+
+  override def beforeEach(): Unit =
+    Files.deleteIfExists(Paths.get(prefetchDb)): Unit
+    prefetchStore = SqlitePrefetchStatusStore(prefetchDb)
+
+  override def afterEach(): Unit =
+    prefetchStore.close()
+    Files.deleteIfExists(Paths.get(prefetchDb)): Unit
+
+  private class TestPlaysCache extends PlaysCache:
+    val store: mutable.Map[String, List[PlayData]] = mutable.Map.empty
+    var touched: List[String] = Nil
+    def save(username: String, plays: List[PlayData]): Unit = store(username) = plays
+    def load(username: String): Option[List[PlayData]] = store.get(username)
+    def isFresh(username: String, maxAgeSeconds: Long): Boolean = false
+    def append(username: String, plays: List[PlayData]): Unit =
+      store(username) = store.getOrElse(username, Nil) ++ plays
+    def maxPlayId(username: String): Option[Int] = store.get(username).flatMap(_.map(_.playId).maxOption)
+    def touch(username: String): Unit = touched = touched :+ username
+
+  private val testPlay = PlayData(1, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)
+
+  "PlaysFetchPageLogic" should:
+
+    "fetch first page and return not done" in:
+      val client = stubClient(playsResult = Right(List(testPlay)))
+      val playsCache = TestPlaysCache()
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"alice","page":1,"sourceType":"collection","sourceId":"alice"}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe false
+      result.hcursor.downField("nextPage").as[Int].toOption.get shouldBe 2
+      result.hcursor.downField("totalSoFar").as[Int].toOption.get shouldBe 1
+      playsCache.store("alice") shouldBe List(testPlay)
+      prefetchStore.get(SourceType.Plays, "alice").map(_.status) shouldBe Some(PrefetchStatus.Processing)
+
+    "mark complete when empty page returned" in:
+      val client = stubClient(playsResult = Right(Nil))
+      val playsCache = TestPlaysCache()
+      playsCache.save("bob", List(testPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"bob","page":2,"sourceType":"collection","sourceId":"bob","cachedMaxPlayId":0}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe true
+      prefetchStore.get(SourceType.Plays, "bob").map(_.status) shouldBe Some(PrefetchStatus.Completed)
+      playsCache.touched should contain("bob")
+
+    "throw on first page failure" in:
+      val client = stubClient(playsResult = Left(Fail.BggRateLimited("rate limited")))
+      val playsCache = TestPlaysCache()
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"charlie","page":1,"sourceType":"collection","sourceId":"charlie"}"""
+
+      intercept[BggRateLimitedException](logic.handle(input))
+
+    "mark complete on error after first page" in:
+      val client = stubClient(playsResult = Left(Fail.BggRateLimited("rate limited")))
+      val playsCache = TestPlaysCache()
+      playsCache.save("dave", List(testPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"dave","page":3,"sourceType":"collection","sourceId":"dave","cachedMaxPlayId":0}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe true
+      prefetchStore.get(SourceType.Plays, "dave").map(_.status) shouldBe Some(PrefetchStatus.Completed)
+
+    "append plays to existing cache" in:
+      val play2 = PlayData(2, GameId(200), "Pandemic", "2024-02-01", 1, 45, Nil)
+      val client = stubClient(playsResult = Right(List(play2)))
+      val playsCache = TestPlaysCache()
+      playsCache.save("eve", List(testPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"eve","page":2,"sourceType":"collection","sourceId":"eve","cachedMaxPlayId":0}"""
+      logic.handle(input)
+
+      playsCache.store("eve") should have size 2
+
+    "short-circuit on page 1 when plays cache is fresh" in:
+      val client = stubClient(playsResult = Right(List(testPlay)))
+      val playsCache = new TestPlaysCache:
+        override def isFresh(username: String, maxAgeSeconds: Long): Boolean = true
+      playsCache.save("frank", List(testPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"frank","page":1,"sourceType":"collection","sourceId":"frank"}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe true
+      result.hcursor.downField("totalSoFar").as[Int].toOption.get shouldBe 1
+      prefetchStore.get(SourceType.Plays, "frank").map(_.status) shouldBe Some(PrefetchStatus.Completed)
+      playsCache.store("frank") shouldBe List(testPlay)
+
+    "stop fetching when hitting already-cached play ID" in:
+      val existingPlay = PlayData(50, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)
+      val newPlay = PlayData(60, GameId(200), "Pandemic", "2024-02-01", 1, 45, Nil)
+      val oldPlay = PlayData(40, GameId(300), "Ticket", "2023-12-01", 1, 90, Nil)
+      val client = stubClient(playsResult = Right(List(newPlay, oldPlay)))
+      val playsCache = TestPlaysCache()
+      playsCache.save("grace", List(existingPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"grace","page":2,"sourceType":"collection","sourceId":"grace","cachedMaxPlayId":50}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe true
+      playsCache.store("grace") should contain(newPlay)
+      playsCache.store("grace") should not contain oldPlay
+      playsCache.touched should contain("grace")
+
+    "resolve cachedMaxPlayId on first page from existing cache" in:
+      val existingPlay = PlayData(100, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)
+      val newPlay = PlayData(200, GameId(200), "Pandemic", "2024-02-01", 1, 45, Nil)
+      val client = stubClient(playsResult = Right(List(newPlay)))
+      val playsCache = TestPlaysCache()
+      playsCache.save("heidi", List(existingPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"heidi","page":1,"sourceType":"collection","sourceId":"heidi"}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe false
+      result.hcursor.downField("cachedMaxPlayId").as[Int].toOption.get shouldBe 100
+      playsCache.store("heidi") should contain(newPlay)
+      playsCache.store("heidi") should contain(existingPlay)
+
+    "first-time fetch with no existing cache sets cachedMaxPlayId to 0" in:
+      val newPlay = PlayData(10, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)
+      val client = stubClient(playsResult = Right(List(newPlay)))
+      val playsCache = TestPlaysCache()
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"ivan","page":1,"sourceType":"collection","sourceId":"ivan"}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe false
+      result.hcursor.downField("cachedMaxPlayId").as[Int].toOption.get shouldBe 0
+      playsCache.store("ivan") shouldBe List(newPlay)
+
+    "cachedMaxPlayId of 0 does not filter any plays" in:
+      val play1 = PlayData(1, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)
+      val play2 = PlayData(2, GameId(200), "Pandemic", "2024-02-01", 1, 45, Nil)
+      val client = stubClient(playsResult = Right(List(play2, play1)))
+      val playsCache = TestPlaysCache()
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"judy","page":2,"sourceType":"collection","sourceId":"judy","cachedMaxPlayId":0}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe false
+      playsCache.store("judy") should contain allOf(play1, play2)
+
+    "does not append empty list when all plays on page are already cached" in:
+      val existingPlay = PlayData(100, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)
+      val oldPlay1 = PlayData(50, GameId(200), "Pandemic", "2024-02-01", 1, 45, Nil)
+      val oldPlay2 = PlayData(30, GameId(300), "Ticket", "2023-12-01", 1, 90, Nil)
+      val client = stubClient(playsResult = Right(List(oldPlay1, oldPlay2)))
+      val playsCache = TestPlaysCache()
+      playsCache.save("kate", List(existingPlay))
+      val logic = PlaysFetchPageLogic(client, playsCache, prefetchStore)
+
+      val input = """{"username":"kate","page":2,"sourceType":"collection","sourceId":"kate","cachedMaxPlayId":100}"""
+      val result = parse(logic.handle(input)).toOption.get
+
+      result.hcursor.downField("done").as[Boolean].toOption.get shouldBe true
+      playsCache.store("kate") shouldBe List(existingPlay)

--- a/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
@@ -99,7 +99,7 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
     "set status to Processing before completion" in:
       var statusDuringFetch: Option[PrefetchStatus] = None
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] =
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] =
           statusDuringFetch = prefetchStore.get(SourceType.Collection, username).map(_.status)
           Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
@@ -122,7 +122,7 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
     "set status to Completed on successful hot games prefetch" in:
       val games = List(testGame(1, "Catan"))
       val hotClient = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(List(GameId(1)))
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(games)

--- a/src/test/scala/bgg/lambda/PrefetchWorkerSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerSpec.scala
@@ -96,7 +96,7 @@ class PrefetchWorkerSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
     "set status to Processing before fetching" in:
       var statusDuringFetch: Option[PrefetchStatus] = None
       val client = new BggClient:
-        def fetchCollection(username: String): Either[Fail, List[GameId]] =
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] =
           statusDuringFetch = prefetchStore.get(SourceType.Collection, username).map(_.status)
           Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)

--- a/src/test/scala/bgg/lambda/StatusUpdaterLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/StatusUpdaterLogicSpec.scala
@@ -1,0 +1,60 @@
+package bgg.lambda
+
+import bgg.domain.SourceType
+import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Files, Paths}
+
+class StatusUpdaterLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
+
+  private val prefetchDb = "test_status_updater.sqlite"
+  private var prefetchStore: SqlitePrefetchStatusStore = _
+
+  override def beforeEach(): Unit =
+    Files.deleteIfExists(Paths.get(prefetchDb)): Unit
+    prefetchStore = SqlitePrefetchStatusStore(prefetchDb)
+
+  override def afterEach(): Unit =
+    prefetchStore.close()
+    Files.deleteIfExists(Paths.get(prefetchDb)): Unit
+
+  "StatusUpdaterLogic" should:
+
+    "set status to processing" in:
+      val logic = StatusUpdaterLogic(prefetchStore)
+      val input = """{"sourceType":"collection","sourceId":"alice","status":"processing"}"""
+
+      logic.handle(input) shouldBe """{"ok":true}"""
+      prefetchStore.get(SourceType.Collection, "alice").map(_.status) shouldBe Some(PrefetchStatus.Processing)
+
+    "set status to completed" in:
+      val logic = StatusUpdaterLogic(prefetchStore)
+      val input = """{"sourceType":"collection","sourceId":"bob","status":"completed"}"""
+
+      logic.handle(input) shouldBe """{"ok":true}"""
+      prefetchStore.get(SourceType.Collection, "bob").map(_.status) shouldBe Some(PrefetchStatus.Completed)
+
+    "set status to failed with reason" in:
+      val logic = StatusUpdaterLogic(prefetchStore)
+      val input = """{"sourceType":"geeklist","sourceId":"123","status":"failed","reason":"BGG timeout"}"""
+
+      logic.handle(input) shouldBe """{"ok":true}"""
+      val record = prefetchStore.get(SourceType.GeeKList, "123")
+      record.map(_.status) shouldBe Some(PrefetchStatus.Failed)
+      record.map(_.reason).get should include("BGG timeout")
+
+    "set status to not_found" in:
+      val logic = StatusUpdaterLogic(prefetchStore)
+      val input = """{"sourceType":"collection","sourceId":"ghost","status":"not_found","reason":"No user found"}"""
+
+      logic.handle(input) shouldBe """{"ok":true}"""
+      prefetchStore.get(SourceType.Collection, "ghost").map(_.status) shouldBe Some(PrefetchStatus.NotFound)
+
+    "throw on invalid source type" in:
+      val logic = StatusUpdaterLogic(prefetchStore)
+      val input = """{"sourceType":"invalid","sourceId":"test","status":"completed"}"""
+
+      intercept[RuntimeException](logic.handle(input))

--- a/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
+++ b/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
@@ -47,7 +47,7 @@ class ApiEndpointsSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach
 
   private def makeEndpoints(bggClient: BggClient): ApiEndpoints =
     val gameService = GameService(bggClient, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
-    ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig)
+    ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpPrefetchTrigger(), testConfig)
 
   private def makeBackend(endpoints: ApiEndpoints): Backend[Identity] =
     TapirStubInterpreter(BackendStub(IdentityMonad))
@@ -493,7 +493,7 @@ class ApiEndpointsSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach
     def makeProxyEndpoints(): ApiEndpoints =
       val client = stubClient()
       val gameService = GameService(client, TestCacheProvider(gameCache, vectorStore), 50, () => Instant.now())
-      ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpSqsSender(), testConfig)
+      ApiEndpoints(gameService, gameCache, vectorStore, prefetchStore, NoOpPrefetchTrigger(), testConfig)
 
     "return 400 for invalid base64 input" in:
       val endpoints = makeProxyEndpoints()


### PR DESCRIPTION
## Summary

Replaces the single-Lambda prefetch worker (which timed out on large collections like Alan How's 6000+ games) with an AWS Step Functions state machine that decomposes work into focused Lambdas with proper retry orchestration.

## Architecture

```
POST /prefetch > StartExecution (Step Functions)
    > SetStatus "processing"
    > Route by sourceType
    > CollectionWorkflow (Parallel):
        Branch 1: FetchCollectionIds > PrepareBatches > Map[GameFetch]
        Branch 2: PlaysLoop (page-by-page with incremental DynamoDB writes)
    > SetStatus "completed"
```

New Lambdas (all share the same native binary, routed by LAMBDA_HANDLER env var):
- **CollectionFetch** - resolves game IDs from BGG collection/geeklist/hot
- **PlaysFetchPage** - fetches one page of plays, appends to DynamoDB cache
- **GameFetch** - fetches game details in parallel sub-batches of 20
- **BatchPreparer** - filters already-cached games, splits remainder into 300-chunks
- **StatusUpdater** - writes prefetch status to DynamoDB

## Issues fixed

- **504 timeout on large collections** - Alan How's 6163-game collection now returns in ~3.5s (was timing out at 29s)
- **SfnClient missing from GraalVM reflect-config** - native binary couldn't instantiate SfnClient, causing silent 500s on /prefetch
- **NPE in DynamoDbPlaysCache.load** - meta items (page 0) created by `updateMaxPlayId` don't have a `data` attribute; wrapped with `Option(item.get("data"))`
- **IndexOutOfBoundsException in nextPageNumber** - `hasItems()` returns true for empty result sets; added `!r.items().isEmpty` guard
- **Step Functions execution name with spaces** - "Alan How" produced invalid execution name; sanitized with `replaceAll("[^a-zA-Z0-9_-]", "_")`
- **DynamoDB table replacement blocked by CloudFormation** - renamed plays table to `production-bgg-plays-v2`
- **Missing IAM permissions** - added `states:*`, `CAPABILITY_NAMED_IAM`, CloudWatch logs for Step Functions
- **BGG 429 rate limit not retried** - `getWithRetry` now retries on 429 with double delay instead of failing immediately
- **fetchGamesByIds swallowing rate limit errors** - previously returned `Right(Nil)` on any failure; now propagates `BggRateLimited` so Step Functions can retry at the orchestration level
- **Non-idiomatic null pattern** - replaced `requestCache: RequestCache = null` with `Option[RequestCache]`

## Performance improvements

- **Gzip compression** - JSON responses >1KB are gzipped when client sends `Accept-Encoding: gzip` (6.3MB > 1.6MB for Alan How)
- **Parallel DynamoDB BatchGetItem** - uses `ox.supervised`/`forkUnsupervised` for concurrent reads across chunks
- **Collection/geeklist ID caching** - stores resolved ID lists in request cache (24h TTL) so subsequent API calls skip the BGG API entirely
- **ID caching during prefetch** - CollectionFetch Lambda pre-warms the request cache so the first API call after prefetch is fast
- **GameFetch throttling** - reduced parallelism from 5>3 with 1s inter-round delay to avoid triggering BGG rate limits
- **Lambda memory 512MB→1024MB** - handles 6000+ game JSON serialization without OOM

## Test plan

- [x] All 312 unit tests pass
- [x] Prefetch Alan How (6163 games) - completes successfully with retry on rate limit
- [x] `GET /collection/Alan How` - 5959 games in 3.5s with gzip
- [x] `GET /collection/teqqles` - 85 games in 0.5s
- [x] `GET /collection/DragonC` -234 games in 0.6s
- [x] `GET /plays/Alan How` - 884 plays in 0.7s
- [x] `GET /plays/teqqles` - 90 plays in 0.25s
- [x] `GET /hot` - 48 games
- [x] `GET /search/catan` - 20 results
- [x] `GET /game/174430` - Gloomhaven
- [x] `GET /prefetch/status/collection/teqqles` - returns completed
- [x] `GET /cors-proxy/{b64url}` - returns image/jpeg without gzip mangling
- [x] All endpoints work with and without `Accept-Encoding: gzip`