### PR TITLE
Per-user collection dates + case-insensitive cache keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ poc/
 # OS
 .DS_Store
 Thumbs.db
+
+# SAM build artifacts
+.aws-sam/

--- a/deployment/build-native.sh
+++ b/deployment/build-native.sh
@@ -16,7 +16,17 @@ docker cp "$CONTAINER_ID:/var/runtime/bootstrap" "$SCRIPT_DIR/bootstrap"
 docker rm "$CONTAINER_ID"
 
 chmod +x "$SCRIPT_DIR/bootstrap"
-zip -j "$SCRIPT_DIR/bgg-api-native.zip" "$SCRIPT_DIR/bootstrap"
+
+rm -f "$SCRIPT_DIR/bgg-api-native.zip"
+if command -v zip >/dev/null 2>&1; then
+  zip -j "$SCRIPT_DIR/bgg-api-native.zip" "$SCRIPT_DIR/bootstrap"
+elif command -v powershell >/dev/null 2>&1; then
+  # Windows/Git Bash fallback: no `zip` on PATH
+  powershell -Command "Compress-Archive -Path '$SCRIPT_DIR/bootstrap' -DestinationPath '$SCRIPT_DIR/bgg-api-native.zip' -Force"
+else
+  echo "Error: neither 'zip' nor 'powershell' found on PATH; cannot package bootstrap." >&2
+  exit 1
+fi
 rm "$SCRIPT_DIR/bootstrap"
 
 echo "Done: $SCRIPT_DIR/bgg-api-native.zip"

--- a/src/main/scala/bgg/bggapi/BggClient.scala
+++ b/src/main/scala/bgg/bggapi/BggClient.scala
@@ -1,10 +1,10 @@
 package bgg.bggapi
 
-import bgg.domain.{Fail, GameData, GameId, PlayData}
+import bgg.domain.{CollectionItem, Fail, GameData, GameId, PlayData}
 
 trait BggClient:
   def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]]
-  def fetchCollection(username: String, retries: Int = 6): Either[Fail, List[GameId]]
+  def fetchCollection(username: String, retries: Int = 6): Either[Fail, List[CollectionItem]]
   def fetchGeeklist(listId: String): Either[Fail, List[GameId]]
   def fetchHotGames(): Either[Fail, List[GameId]]
   def searchGames(query: String): Either[Fail, List[GameData]]

--- a/src/main/scala/bgg/bggapi/BggXmlClient.scala
+++ b/src/main/scala/bgg/bggapi/BggXmlClient.scala
@@ -1,7 +1,7 @@
 package bgg.bggapi
 
 import bgg.config.BggConfig
-import bgg.domain.{Fail, GameData, GameId, PlayData}
+import bgg.domain.{CollectionItem, Fail, GameData, GameId, PlayData}
 import com.typesafe.scalalogging.StrictLogging
 import sttp.client4.*
 import sttp.model.StatusCode
@@ -71,7 +71,7 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
         }
       }
 
-  def fetchCollection(username: String, retries: Int = config.retries): Either[Fail, List[GameId]] =
+  def fetchCollection(username: String, retries: Int = config.retries): Either[Fail, List[CollectionItem]] =
     getWithRetry(
       s"$ApiV2Base/collection",
       Map("username" -> username, "own" -> "1", "excludesubtype" -> "boardgameexpansion"),
@@ -80,8 +80,21 @@ class BggXmlClient(config: BggConfig, backend: SyncBackend) extends BggClient wi
       .flatMap { xml =>
         val items = (xml \ "item")
         if items.isEmpty then Left(Fail.BggUserNotFound(username))
-        else Right(items.toList.flatMap(n => (n \ "@objectid").headOption.map(id => GameId(id.text.toInt))))
+        else
+          Right(items.toList.flatMap { n =>
+            (n \ "@objectid").headOption.map { id =>
+              CollectionItem(GameId(id.text.toInt), collectionLastModified(n))
+            }
+          })
       }
+
+  // BGG exposes no "dateadded"; status/@lastmodified is the closest per-item date, and for an
+  // owned item reflects when it entered the collection. take(10) keeps the date, dropping BGG's time.
+  private def collectionLastModified(item: scala.xml.Node): Option[String] =
+    (item \ "status" \ "@lastmodified").headOption
+      .map(_.text.trim)
+      .filter(_.nonEmpty)
+      .map(_.take(10))
 
   def fetchGeeklist(listId: String): Either[Fail, List[GameId]] =
     getWithRetry(s"$ApiV1Base/geeklist/$listId")

--- a/src/main/scala/bgg/bggapi/GameService.scala
+++ b/src/main/scala/bgg/bggapi/GameService.scala
@@ -1,6 +1,6 @@
 package bgg.bggapi
 
-import bgg.cache.CacheProvider
+import bgg.cache.{CacheKeys, CacheProvider}
 import bgg.domain.{CollectionItem, CollectionResult, Fail, GameData, GameId, PlayData}
 import bgg.store.StoredVector
 import bgg.vector.VectorMath
@@ -34,8 +34,8 @@ class GameService(
   // Per-user collection metadata (lastModified date) is kept separate from the globally-shared
   // GameData cache so one user's dates never leak into another's collection or /hot.
   def resolveCollection(username: String): Either[Fail, CollectionResult] =
-    val idsKey = s"collection-ids:$username"
-    val datesKey = s"collection-dates:$username"
+    val idsKey = CacheKeys.collectionIds(username)
+    val datesKey = CacheKeys.collectionDates(username)
     requestCache.load[List[Int]](idsKey) match
       case Some(ids) =>
         logger.debug(s"Collection IDs for $username served from request cache (${ids.size} ids)")
@@ -56,7 +56,7 @@ class GameService(
       .flatMap((idString, date) => idString.toIntOption.map(id => GameId(id) -> date))
 
   def resolveGeeklist(listId: String): Either[Fail, List[GameData]] =
-    val cacheKey = s"geeklist-ids:$listId"
+    val cacheKey = CacheKeys.geeklistIds(listId)
     requestCache.load[List[Int]](cacheKey) match
       case Some(ids) =>
         logger.debug(s"Geeklist IDs for $listId served from request cache (${ids.size} ids)")

--- a/src/main/scala/bgg/bggapi/GameService.scala
+++ b/src/main/scala/bgg/bggapi/GameService.scala
@@ -1,7 +1,7 @@
 package bgg.bggapi
 
 import bgg.cache.CacheProvider
-import bgg.domain.{Fail, GameData, GameId, PlayData}
+import bgg.domain.{CollectionItem, CollectionResult, Fail, GameData, GameId, PlayData}
 import bgg.store.StoredVector
 import bgg.vector.VectorMath
 import com.typesafe.scalalogging.StrictLogging
@@ -31,17 +31,29 @@ class GameService(
 
   private val CollectionIdsTtlSeconds = 24L * 3600
 
-  def resolveCollection(username: String): Either[Fail, List[GameData]] =
-    val cacheKey = s"collection-ids:$username"
-    requestCache.load[List[Int]](cacheKey) match
+  // Per-user collection metadata (lastModified date) is kept separate from the globally-shared
+  // GameData cache so one user's dates never leak into another's collection or /hot.
+  def resolveCollection(username: String): Either[Fail, CollectionResult] =
+    val idsKey = s"collection-ids:$username"
+    val datesKey = s"collection-dates:$username"
+    requestCache.load[List[Int]](idsKey) match
       case Some(ids) =>
         logger.debug(s"Collection IDs for $username served from request cache (${ids.size} ids)")
-        resolveGameIds(ids.map(GameId(_)))
+        val lastModified = loadCachedDates(datesKey)
+        resolveGameIds(ids.map(GameId(_))).map(games => CollectionResult(games, lastModified))
       case None =>
-        bggClient.fetchCollection(username).flatMap { ids =>
-          requestCache.save(cacheKey, ids.map(_.value), CollectionIdsTtlSeconds, clock())
-          resolveGameIds(ids)
+        bggClient.fetchCollection(username).flatMap { items =>
+          requestCache.save(idsKey, items.map(_.id.value), CollectionIdsTtlSeconds, clock())
+          requestCache.save(datesKey, CollectionItem.datesByIdString(items), CollectionIdsTtlSeconds, clock())
+          val lastModified = CollectionItem.datesByGameId(items)
+          resolveGameIds(items.map(_.id)).map(games => CollectionResult(games, lastModified))
         }
+
+  private def loadCachedDates(key: String): Map[GameId, String] =
+    requestCache
+      .load[Map[String, String]](key)
+      .getOrElse(Map.empty)
+      .flatMap((idString, date) => idString.toIntOption.map(id => GameId(id) -> date))
 
   def resolveGeeklist(listId: String): Either[Fail, List[GameData]] =
     val cacheKey = s"geeklist-ids:$listId"

--- a/src/main/scala/bgg/cache/CacheKeys.scala
+++ b/src/main/scala/bgg/cache/CacheKeys.scala
@@ -1,0 +1,15 @@
+package bgg.cache
+
+/** Central place for building DynamoDB cache keys.
+  *
+  * BGG usernames (and other user-supplied identifiers) are case-insensitive, so every key derived from one is
+  * normalized to trimmed lowercase. Constructing the keys here keeps the API read path and the Step Functions write
+  * path from ever diverging on casing or surrounding whitespace.
+  */
+object CacheKeys:
+  /** Trim + lowercase so a given identifier always maps to one key regardless of input casing. */
+  def normalize(id: String): String = id.trim.toLowerCase
+
+  def collectionIds(username: String): String = s"collection-ids:${normalize(username)}"
+  def collectionDates(username: String): String = s"collection-dates:${normalize(username)}"
+  def geeklistIds(listId: String): String = s"geeklist-ids:${normalize(listId)}"

--- a/src/main/scala/bgg/cache/DynamoDbGameCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbGameCache.scala
@@ -61,9 +61,13 @@ class DynamoDbGameCache(client: DynamoDbClient, tableName: String) extends GameC
     if ids.isEmpty then return Nil
     val chunks = ids.distinct.grouped(BatchGetMaxKeys).toList
     if chunks.size <= 1 then
-      chunks.flatMap(chunk => fetchBatchWithRetry(
-        chunk.map(id => Map("id" -> AttributeValue.fromS(id.asString)).asJava), Nil, BatchGetMaxRetries
-      ))
+      chunks.flatMap(chunk =>
+        fetchBatchWithRetry(
+          chunk.map(id => Map("id" -> AttributeValue.fromS(id.asString)).asJava),
+          Nil,
+          BatchGetMaxRetries
+        )
+      )
     else
       supervised:
         val forks = chunks.map { chunk =>

--- a/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
+++ b/src/main/scala/bgg/cache/DynamoDbPlaysCache.scala
@@ -44,19 +44,21 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
   private val TtlDays = 7L
   private val MetaPage = 0
 
-  def save(username: String, plays: List[PlayData]): Unit =
+  def save(rawUsername: String, plays: List[PlayData]): Unit =
+    val username = CacheKeys.normalize(rawUsername)
     val now = clock()
     val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
     deleteAllPages(username)
     val maxId = plays.map(_.playId).maxOption.getOrElse(0)
     putPage(username, MetaPage, plays, now, ttl, maxId)
 
-  def load(username: String): Option[List[PlayData]] =
+  def load(rawUsername: String): Option[List[PlayData]] =
+    val username = CacheKeys.normalize(rawUsername)
     val request = QueryRequest
       .builder()
       .tableName(tableName)
       .keyConditionExpression("username = :u")
-      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username)).asJava)
       .build()
 
     tryAwsCall(client.query(request), s"Error loading plays for $username")
@@ -67,21 +69,22 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
           .asScala
           .toList
           .flatMap { item =>
-            Option(item.get("data")).flatMap(attr =>
-              decodeJson[List[PlayData]](attr.s(), s"plays chunk for $username")
-            ).getOrElse(Nil)
+            Option(item.get("data"))
+              .flatMap(attr => decodeJson[List[PlayData]](attr.s(), s"plays chunk for $username"))
+              .getOrElse(Nil)
           }
           .sortBy(_.playId)(Ordering[Int].reverse)
       }
       .filter(_.nonEmpty)
 
-  def isFresh(username: String, maxAgeSeconds: Long): Boolean =
+  def isFresh(rawUsername: String, maxAgeSeconds: Long): Boolean =
+    val username = CacheKeys.normalize(rawUsername)
     val request = GetItemRequest
       .builder()
       .tableName(tableName)
       .key(
         Map(
-          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "username" -> AttributeValue.fromS(username),
           "page" -> AttributeValue.fromN(MetaPage.toString)
         ).asJava
       )
@@ -98,20 +101,22 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
         age < maxAgeSeconds
       }
 
-  def append(username: String, plays: List[PlayData]): Unit =
+  def append(rawUsername: String, plays: List[PlayData]): Unit =
+    val username = CacheKeys.normalize(rawUsername)
     val now = clock()
     val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
     val nextPage = nextPageNumber(username)
     putPage(username, nextPage, plays, now, ttl)
     plays.map(_.playId).maxOption.foreach(updateMaxPlayId(username, _))
 
-  def maxPlayId(username: String): Option[Int] =
+  def maxPlayId(rawUsername: String): Option[Int] =
+    val username = CacheKeys.normalize(rawUsername)
     val request = GetItemRequest
       .builder()
       .tableName(tableName)
       .key(
         Map(
-          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "username" -> AttributeValue.fromS(username),
           "page" -> AttributeValue.fromN(MetaPage.toString)
         ).asJava
       )
@@ -124,7 +129,8 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
       .map(_.n().toInt)
       .filter(_ > 0)
 
-  def touch(username: String): Unit =
+  def touch(rawUsername: String): Unit =
+    val username = CacheKeys.normalize(rawUsername)
     val now = clock()
     val ttl = now.plusSeconds(TtlDays * 24 * 3600).getEpochSecond
     val request = UpdateItemRequest
@@ -132,7 +138,7 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
       .tableName(tableName)
       .key(
         Map(
-          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "username" -> AttributeValue.fromS(username),
           "page" -> AttributeValue.fromN(MetaPage.toString)
         ).asJava
       )
@@ -148,16 +154,26 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
     try client.updateItem(request): Unit
     catch case e: Exception => logger.warn(s"Error touching freshness for $username", e)
 
-  private def putPage(username: String, page: Int, plays: List[PlayData], now: Instant, ttl: Long, maxId: Int = 0): Unit =
+  // The public methods normalize the username before delegating here, so these private helpers
+  // receive an already-normalized key.
+  private def putPage(
+      username: String,
+      page: Int,
+      plays: List[PlayData],
+      now: Instant,
+      ttl: Long,
+      maxId: Int = 0
+  ): Unit =
     val baseItem = Map(
-      "username" -> AttributeValue.fromS(username.toLowerCase),
+      "username" -> AttributeValue.fromS(username),
       "page" -> AttributeValue.fromN(page.toString),
       "data" -> AttributeValue.fromS(plays.asJson.noSpaces),
       "cached_at" -> AttributeValue.fromN(now.getEpochSecond.toString),
       "ttl" -> AttributeValue.fromN(ttl.toString)
     )
-    val item = if maxId > 0 then baseItem + ("max_play_id" -> AttributeValue.fromN(maxId.toString))
-    else baseItem
+    val item =
+      if maxId > 0 then baseItem + ("max_play_id" -> AttributeValue.fromN(maxId.toString))
+      else baseItem
 
     val request = PutItemRequest.builder().tableName(tableName).item(item.asJava).build()
     try
@@ -173,7 +189,7 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
       .tableName(tableName)
       .key(
         Map(
-          "username" -> AttributeValue.fromS(username.toLowerCase),
+          "username" -> AttributeValue.fromS(username),
           "page" -> AttributeValue.fromN(MetaPage.toString)
         ).asJava
       )
@@ -184,14 +200,14 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
     try client.updateItem(request): Unit
     catch
       case _: ConditionalCheckFailedException => ()
-      case e: Exception => logger.warn(s"Error updating maxPlayId for $username", e)
+      case e: Exception                       => logger.warn(s"Error updating maxPlayId for $username", e)
 
   private def nextPageNumber(username: String): Int =
     val request = QueryRequest
       .builder()
       .tableName(tableName)
       .keyConditionExpression("username = :u")
-      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username)).asJava)
       .projectionExpression("#p")
       .expressionAttributeNames(Map("#p" -> "page").asJava)
       .scanIndexForward(false)
@@ -208,7 +224,7 @@ class DynamoDbPlaysCache(client: DynamoDbClient, tableName: String, clock: () =>
       .builder()
       .tableName(tableName)
       .keyConditionExpression("username = :u")
-      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username.toLowerCase)).asJava)
+      .expressionAttributeValues(Map(":u" -> AttributeValue.fromS(username)).asJava)
       .projectionExpression("username, #p")
       .expressionAttributeNames(Map("#p" -> "page").asJava)
       .build()

--- a/src/main/scala/bgg/domain/Model.scala
+++ b/src/main/scala/bgg/domain/Model.scala
@@ -22,6 +22,21 @@ object Username:
   def apply(value: String): Username = value
   extension (u: Username) def value: String = u
 
+// lastModified lives here rather than on GameData because GameData is cached globally per
+// game, whereas the collection date is per-user.
+case class CollectionItem(id: GameId, lastModified: Option[String])
+
+object CollectionItem:
+  // Dates keyed by GameId for in-memory use; items without a date are omitted.
+  def datesByGameId(items: List[CollectionItem]): Map[GameId, String] =
+    items.flatMap(item => item.lastModified.map(item.id -> _)).toMap
+
+  // GameId is opaque over Int, so the cache persists dates with String keys instead.
+  def datesByIdString(items: List[CollectionItem]): Map[String, String] =
+    items.flatMap(item => item.lastModified.map(item.id.asString -> _)).toMap
+
+case class CollectionResult(games: List[GameData], lastModifiedByGame: Map[GameId, String])
+
 enum SourceType:
   case Collection, GeeKList, Hot, Plays
   def toPathSegment: String = this match

--- a/src/main/scala/bgg/lambda/BatchPreparerLogic.scala
+++ b/src/main/scala/bgg/lambda/BatchPreparerLogic.scala
@@ -15,8 +15,10 @@ class BatchPreparerLogic(gameCache: GameCache) extends StrictLogging:
     val uncached = filterCached(gameIds)
     val chunks = uncached.grouped(ChunkSize).toList
 
-    logger.info(s"BatchPreparer: ${gameIds.size} total, ${gameIds.size - uncached.size} cached, " +
-      s"${uncached.size} to fetch in ${chunks.size} chunks")
+    logger.info(
+      s"BatchPreparer: ${gameIds.size} total, ${gameIds.size - uncached.size} cached, " +
+        s"${uncached.size} to fetch in ${chunks.size} chunks"
+    )
 
     val result = chunks.map { chunk =>
       Json.obj(
@@ -28,7 +30,9 @@ class BatchPreparerLogic(gameCache: GameCache) extends StrictLogging:
     Json.fromValues(result).noSpaces
 
   private def parseInput(json: String): (List[GameId], String, String) =
-    parser.parse(json).toOption
+    parser
+      .parse(json)
+      .toOption
       .flatMap { j =>
         for
           ids <- j.hcursor.downField("gameIds").as[List[Int]].toOption

--- a/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
@@ -1,7 +1,7 @@
 package bgg.lambda
 
 import bgg.bggapi.BggClient
-import bgg.cache.RequestCache
+import bgg.cache.{CacheKeys, RequestCache}
 import bgg.domain.{CollectionItem, Fail, GameId, SourceType}
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.{Json, parser}
@@ -44,8 +44,8 @@ class CollectionFetchLogic(
 
   private def cacheIds(input: CollectionFetchInput, ids: List[GameId]): Unit =
     val cacheKey = SourceType.fromString(input.sourceType).toOption match
-      case Some(SourceType.Collection) => Some(s"collection-ids:${input.sourceId}")
-      case Some(SourceType.GeeKList)   => Some(s"geeklist-ids:${input.sourceId}")
+      case Some(SourceType.Collection) => Some(CacheKeys.collectionIds(input.sourceId))
+      case Some(SourceType.GeeKList)   => Some(CacheKeys.geeklistIds(input.sourceId))
       case _                           => None
 
     for
@@ -58,7 +58,7 @@ class CollectionFetchLogic(
   private def cacheCollectionDates(input: CollectionFetchInput, items: List[CollectionItem]): Unit =
     if SourceType.fromString(input.sourceType).contains(SourceType.Collection) then
       val dates = CollectionItem.datesByIdString(items)
-      requestCache.foreach(_.save(s"collection-dates:${input.sourceId}", dates, IdsCacheTtlSeconds, clock()))
+      requestCache.foreach(_.save(CacheKeys.collectionDates(input.sourceId), dates, IdsCacheTtlSeconds, clock()))
 
   private def parseInput(json: String): Either[Fail, CollectionFetchInput] =
     parser

--- a/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/CollectionFetchLogic.scala
@@ -2,7 +2,7 @@ package bgg.lambda
 
 import bgg.bggapi.BggClient
 import bgg.cache.RequestCache
-import bgg.domain.{Fail, GameId, SourceType}
+import bgg.domain.{CollectionItem, Fail, GameId, SourceType}
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.{Json, parser}
 import io.circe.syntax.*
@@ -24,18 +24,21 @@ class CollectionFetchLogic(
   def handle(eventJson: String): String =
     val result = for
       input <- parseInput(eventJson)
-      ids <- fetchIds(input)
+      items <- fetchItems(input)
     yield
-      cacheIds(input, ids)
-      CollectionFetchOutput(ids.map(_.value), input.sourceType, input.sourceId)
+      cacheIds(input, items.map(_.id))
+      cacheCollectionDates(input, items)
+      CollectionFetchOutput(items.map(_.id.value), input.sourceType, input.sourceId)
 
     result match
       case Right(output) =>
-        Json.obj(
-          "gameIds" -> output.gameIds.asJson,
-          "sourceType" -> Json.fromString(output.sourceType),
-          "sourceId" -> Json.fromString(output.sourceId)
-        ).noSpaces
+        Json
+          .obj(
+            "gameIds" -> output.gameIds.asJson,
+            "sourceType" -> Json.fromString(output.sourceType),
+            "sourceId" -> Json.fromString(output.sourceId)
+          )
+          .noSpaces
       case Left(fail) =>
         throw toLambdaException(fail)
 
@@ -50,8 +53,17 @@ class CollectionFetchLogic(
       key <- cacheKey
     do cache.save(key, ids.map(_.value), IdsCacheTtlSeconds, clock())
 
+  // Per-user collection dates are cached under a separate key so the collection endpoint
+  // can enrich its response; see GameService.resolveCollection. Only collections carry dates.
+  private def cacheCollectionDates(input: CollectionFetchInput, items: List[CollectionItem]): Unit =
+    if SourceType.fromString(input.sourceType).contains(SourceType.Collection) then
+      val dates = CollectionItem.datesByIdString(items)
+      requestCache.foreach(_.save(s"collection-dates:${input.sourceId}", dates, IdsCacheTtlSeconds, clock()))
+
   private def parseInput(json: String): Either[Fail, CollectionFetchInput] =
-    parser.parse(json).toOption
+    parser
+      .parse(json)
+      .toOption
       .flatMap { j =>
         for
           st <- j.hcursor.downField("sourceType").as[String].toOption
@@ -60,7 +72,7 @@ class CollectionFetchLogic(
       }
       .toRight(Fail.IncorrectInput("Invalid input JSON"))
 
-  private def fetchIds(input: CollectionFetchInput): Either[Fail, List[GameId]] =
+  private def fetchItems(input: CollectionFetchInput): Either[Fail, List[CollectionItem]] =
     SourceType.fromString(input.sourceType) match
       case Left(err) => Left(Fail.IncorrectInput(err))
       case Right(SourceType.Collection) =>
@@ -68,12 +80,16 @@ class CollectionFetchLogic(
         bggClient.fetchCollection(input.sourceId, retries)
       case Right(SourceType.GeeKList) =>
         logger.info(s"Fetching geeklist ${input.sourceId}")
-        bggClient.fetchGeeklist(input.sourceId)
+        bggClient.fetchGeeklist(input.sourceId).map(datelessItems)
       case Right(SourceType.Hot) =>
         logger.info(s"Fetching hot games")
-        bggClient.fetchHotGames()
+        bggClient.fetchHotGames().map(datelessItems)
       case Right(SourceType.Plays) =>
         Left(Fail.IncorrectInput("Plays is not a valid source type for collection fetch"))
+
+  // Geeklists and hot games have no collection-level dates; wrap their ids to share one flow.
+  private def datelessItems(ids: List[GameId]): List[CollectionItem] =
+    ids.map(id => CollectionItem(id, None))
 
   private def toLambdaException(fail: Fail): RuntimeException = fail match
     case Fail.BggRateLimited(msg) => BggRateLimitedException(msg)

--- a/src/main/scala/bgg/lambda/GameFetchLogic.scala
+++ b/src/main/scala/bgg/lambda/GameFetchLogic.scala
@@ -31,7 +31,9 @@ class GameFetchLogic(
     toJson(output)
 
   private def parseInput(json: String): List[GameId] =
-    parser.parse(json).toOption
+    parser
+      .parse(json)
+      .toOption
       .flatMap(_.hcursor.downField("gameIds").as[List[Int]].toOption)
       .map(_.map(GameId(_)))
       .getOrElse(throw RuntimeException("Invalid input JSON for GameFetch"))
@@ -40,8 +42,7 @@ class GameFetchLogic(
     val (alreadyCached, missing) = partitionCached(ids)
     logger.info(s"GameFetch: ${ids.size} total, ${alreadyCached.size} already cached, ${missing.size} to fetch")
 
-    if missing.isEmpty then
-      return GameFetchOutput(ids.map(_.value), Nil, alreadyCached.size)
+    if missing.isEmpty then return GameFetchOutput(ids.map(_.value), Nil, alreadyCached.size)
 
     val subBatches = missing.grouped(SubBatchSize).toList
     val results = processSubBatchesParallel(subBatches)
@@ -98,8 +99,10 @@ class GameFetchLogic(
       )
 
   private def toJson(output: GameFetchOutput): String =
-    Json.obj(
-      "succeeded" -> output.succeeded.asJson,
-      "failed" -> output.failed.asJson,
-      "totalCached" -> Json.fromInt(output.totalCached)
-    ).noSpaces
+    Json
+      .obj(
+        "succeeded" -> output.succeeded.asJson,
+        "failed" -> output.failed.asJson,
+        "totalCached" -> Json.fromInt(output.totalCached)
+      )
+      .noSpaces

--- a/src/main/scala/bgg/lambda/NativeBootstrap.scala
+++ b/src/main/scala/bgg/lambda/NativeBootstrap.scala
@@ -74,8 +74,7 @@ object NativeBootstrap:
         val withCors = response.copy(headers = response.headers ++ corsHeaders)
         val isJsonResponse = withCors.headers.get("Content-Type").exists(_.contains("application/json"))
         val compressed =
-          if acceptsGzip && isJsonResponse && withCors.body.length > 1024 then
-            gzipResponse(withCors)
+          if acceptsGzip && isJsonResponse && withCors.body.length > 1024 then gzipResponse(withCors)
           else withCors
         compressed.asJson.noSpaces
 
@@ -87,7 +86,8 @@ object NativeBootstrap:
     val config = AppConfig.load()
     val httpBackend = DefaultSyncBackend()
     val bggClient = BggXmlClient(config.bgg, httpBackend)
-    val dynamo = DynamoDbClient.builder()
+    val dynamo = DynamoDbClient
+      .builder()
       .region(Region.of(config.aws.region))
       .httpClient(UrlConnectionHttpClient.create())
       .build()
@@ -99,7 +99,8 @@ object NativeBootstrap:
     val config = AppConfig.load()
     val httpBackend = DefaultSyncBackend()
     val bggClient = BggXmlClient(config.bgg, httpBackend)
-    val dynamo = DynamoDbClient.builder()
+    val dynamo = DynamoDbClient
+      .builder()
       .region(Region.of(config.aws.region))
       .httpClient(UrlConnectionHttpClient.create())
       .build()
@@ -112,7 +113,8 @@ object NativeBootstrap:
     val config = AppConfig.load()
     val httpBackend = DefaultSyncBackend()
     val bggClient = BggXmlClient(config.bgg, httpBackend)
-    val dynamo = DynamoDbClient.builder()
+    val dynamo = DynamoDbClient
+      .builder()
       .region(Region.of(config.aws.region))
       .httpClient(UrlConnectionHttpClient.create())
       .build()
@@ -122,7 +124,8 @@ object NativeBootstrap:
 
   private def buildBatchPreparerRoute(): String => String =
     val config = AppConfig.load()
-    val dynamo = DynamoDbClient.builder()
+    val dynamo = DynamoDbClient
+      .builder()
       .region(Region.of(config.aws.region))
       .httpClient(UrlConnectionHttpClient.create())
       .build()
@@ -132,7 +135,8 @@ object NativeBootstrap:
 
   private def buildStatusUpdaterRoute(): String => String =
     val config = AppConfig.load()
-    val dynamo = DynamoDbClient.builder()
+    val dynamo = DynamoDbClient
+      .builder()
       .region(Region.of(config.aws.region))
       .httpClient(UrlConnectionHttpClient.create())
       .build()

--- a/src/main/scala/bgg/lambda/PlaysFetchPageLogic.scala
+++ b/src/main/scala/bgg/lambda/PlaysFetchPageLogic.scala
@@ -7,8 +7,22 @@ import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore}
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.{Json, parser}
 
-case class PlaysFetchPageInput(username: String, page: Int, sourceType: String, sourceId: String, cachedMaxPlayId: Option[Int])
-case class PlaysFetchPageOutput(nextPage: Int, done: Boolean, totalSoFar: Int, username: String, sourceType: String, sourceId: String, cachedMaxPlayId: Option[Int])
+case class PlaysFetchPageInput(
+    username: String,
+    page: Int,
+    sourceType: String,
+    sourceId: String,
+    cachedMaxPlayId: Option[Int]
+)
+case class PlaysFetchPageOutput(
+    nextPage: Int,
+    done: Boolean,
+    totalSoFar: Int,
+    username: String,
+    sourceType: String,
+    sourceId: String,
+    cachedMaxPlayId: Option[Int]
+)
 
 class PlaysFetchPageLogic(
     bggClient: BggClient,
@@ -23,7 +37,9 @@ class PlaysFetchPageLogic(
     toJson(result)
 
   private def parseInput(json: String): PlaysFetchPageInput =
-    parser.parse(json).toOption
+    parser
+      .parse(json)
+      .toOption
       .flatMap { j =>
         for
           username <- j.hcursor.downField("username").as[String].toOption
@@ -55,8 +71,7 @@ class PlaysFetchPageLogic(
       val maxId = playsCache.maxPlayId(input.username)
       prefetchStore.set(SourceType.Plays, input.username, PrefetchStatus.Processing)
       maxId
-    else
-      input.cachedMaxPlayId
+    else input.cachedMaxPlayId
 
     bggClient.fetchPlays(input.username, input.page) match
       case Right(plays) if plays.nonEmpty =>
@@ -67,8 +82,7 @@ class PlaysFetchPageLogic(
           case None =>
             (plays, false)
 
-        if newPlays.nonEmpty then
-          playsCache.append(input.username, newPlays)
+        if newPlays.nonEmpty then playsCache.append(input.username, newPlays)
 
         if hitCached then
           markPlaysComplete(input.username)
@@ -139,12 +153,14 @@ class PlaysFetchPageLogic(
     playsCache.load(username).map(_.size).getOrElse(0)
 
   private def toJson(output: PlaysFetchPageOutput): String =
-    Json.obj(
-      "nextPage" -> Json.fromInt(output.nextPage),
-      "done" -> Json.fromBoolean(output.done),
-      "totalSoFar" -> Json.fromInt(output.totalSoFar),
-      "username" -> Json.fromString(output.username),
-      "sourceType" -> Json.fromString(output.sourceType),
-      "sourceId" -> Json.fromString(output.sourceId),
-      "cachedMaxPlayId" -> output.cachedMaxPlayId.fold(Json.fromInt(0))(Json.fromInt)
-    ).noSpaces
+    Json
+      .obj(
+        "nextPage" -> Json.fromInt(output.nextPage),
+        "done" -> Json.fromBoolean(output.done),
+        "totalSoFar" -> Json.fromInt(output.totalSoFar),
+        "username" -> Json.fromString(output.username),
+        "sourceType" -> Json.fromString(output.sourceType),
+        "sourceId" -> Json.fromString(output.sourceId),
+        "cachedMaxPlayId" -> output.cachedMaxPlayId.fold(Json.fromInt(0))(Json.fromInt)
+      )
+      .noSpaces

--- a/src/main/scala/bgg/lambda/PrefetchWorker.scala
+++ b/src/main/scala/bgg/lambda/PrefetchWorker.scala
@@ -86,7 +86,7 @@ class PrefetchWorkerLogic(
               gameService.resolveCollection(msg.sourceId),
               gameService.fetchAndCachePlays(msg.sourceId)
             )
-            collectionResult
+            collectionResult.map(_.games)
           case SourceType.GeeKList => gameService.resolveGeeklist(msg.sourceId)
           case SourceType.Hot      => gameService.resolveHotGames()
           case SourceType.Plays    => Right(Nil)

--- a/src/main/scala/bgg/lambda/StatusUpdaterLogic.scala
+++ b/src/main/scala/bgg/lambda/StatusUpdaterLogic.scala
@@ -14,7 +14,9 @@ class StatusUpdaterLogic(prefetchStore: PrefetchStatusStore) extends StrictLoggi
     """{"ok":true}"""
 
   private def parseInput(json: String): (SourceType, String, PrefetchStatus, String) =
-    parser.parse(json).toOption
+    parser
+      .parse(json)
+      .toOption
       .flatMap { j =>
         for
           st <- j.hcursor.downField("sourceType").as[String].toOption
@@ -22,9 +24,11 @@ class StatusUpdaterLogic(prefetchStore: PrefetchStatusStore) extends StrictLoggi
           status <- j.hcursor.downField("status").as[String].toOption
         yield
           val reason = j.hcursor.downField("reason").as[String].getOrElse("")
-          val sourceType = SourceType.fromString(st).getOrElse(
-            throw RuntimeException(s"Invalid sourceType: $st")
-          )
+          val sourceType = SourceType
+            .fromString(st)
+            .getOrElse(
+              throw RuntimeException(s"Invalid sourceType: $st")
+            )
           val prefetchStatus = PrefetchStatus.fromDbKey(status)
           (sourceType, si, prefetchStatus, reason)
       }

--- a/src/main/scala/bgg/prefetch/PrefetchStatusStore.scala
+++ b/src/main/scala/bgg/prefetch/PrefetchStatusStore.scala
@@ -52,5 +52,7 @@ trait PrefetchStatusStore:
       case None         => true
       case Some(record) => record.status == PrefetchStatus.Failed
 
+  // sourceId is user-supplied (often a BGG username) and case-insensitive, so normalize it to
+  // trimmed lowercase — the same normalization the data caches use — so status and data keys agree.
   private[prefetch] def statusKey(sourceType: SourceType, sourceId: String): String =
-    s"${sourceType.toPathSegment}:$sourceId"
+    s"${sourceType.toPathSegment}:${bgg.cache.CacheKeys.normalize(sourceId)}"

--- a/src/main/scala/bgg/routes/ApiEndpoints.scala
+++ b/src/main/scala/bgg/routes/ApiEndpoints.scala
@@ -3,7 +3,7 @@ package bgg.routes
 import bgg.bggapi.GameService
 import bgg.cache.GameCache
 import bgg.config.AppConfig
-import bgg.domain.{Fail, GameData, GameId, SourceType}
+import bgg.domain.{CollectionResult, Fail, GameData, GameFilters, GameId, SourceType}
 import bgg.filter.GameFilter
 import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore}
 import bgg.recommendation.{RecommendationEngine, RecommendedGame}
@@ -67,7 +67,25 @@ class ApiEndpoints(
     }
 
   // GET /collection/:username
-  val collectionEndpoint = gameListEndpoint("collection", SourceType.Collection, gameService.resolveCollection)
+  // Does not share gameListEndpoint: the response is enriched with per-user lastModified dates.
+  val collectionEndpoint = baseEndpoint.get
+    .in("collection" / path[String]("id"))
+    .in(headers)
+    .out(jsonBody[List[Json]])
+    .handle { (id, hdrs) =>
+      checkPrefetchBlock(SourceType.Collection, id)
+        .getOrElse {
+          val filters = HeaderFilters.fromHeaders(hdrs)
+          gameService.resolveCollection(id).map(result => collectionJson(result, filters))
+        }
+    }
+
+  private def collectionJson(result: CollectionResult, filters: GameFilters): List[Json] =
+    val enriched = GameFilter(result.games, filters).map { game =>
+      val lastModified = result.lastModifiedByGame.get(game.id).fold(Json.Null)(Json.fromString)
+      game.toJson.deepMerge(Json.obj("lastmodified" -> lastModified))
+    }
+    FieldReduction.filterFields(enriched, filters.fieldWhitelist)
 
   // GET /geeklist/:id
   val geeklistEndpoint = gameListEndpoint("geeklist", SourceType.GeeKList, gameService.resolveGeeklist)
@@ -156,8 +174,7 @@ class ApiEndpoints(
             "plays" -> Json.fromValues(groupedPlays),
             "meta" -> playsMetadata(username)
           )
-        else
-          Json.fromValues(groupedPlays)
+        else Json.fromValues(groupedPlays)
       }
     }
 
@@ -188,7 +205,7 @@ class ApiEndpoints(
     .out(statusCode and jsonBody[PrefetchResponse])
     .handle { req =>
       SourceType.fromString(req.sourceType) match
-        case Left(e) => Left(Fail.IncorrectInput(e))
+        case Left(e)           => Left(Fail.IncorrectInput(e))
         case Right(sourceType) =>
           val sourceId = req.sourceId.trim
           if sourceId.isEmpty then Left(Fail.IncorrectInput("source_id must not be empty"))

--- a/src/main/scala/bgg/routes/ApiEndpoints.scala
+++ b/src/main/scala/bgg/routes/ApiEndpoints.scala
@@ -1,7 +1,7 @@
 package bgg.routes
 
 import bgg.bggapi.GameService
-import bgg.cache.GameCache
+import bgg.cache.{CacheKeys, GameCache}
 import bgg.config.AppConfig
 import bgg.domain.{CollectionResult, Fail, GameData, GameFilters, GameId, SourceType}
 import bgg.filter.GameFilter
@@ -207,7 +207,9 @@ class ApiEndpoints(
       SourceType.fromString(req.sourceType) match
         case Left(e)           => Left(Fail.IncorrectInput(e))
         case Right(sourceType) =>
-          val sourceId = req.sourceId.trim
+          // Normalize once at the entry point so the whole prefetch pipeline — Step Functions
+          // input, status keys, and the downstream data caches — carries the same identifier.
+          val sourceId = CacheKeys.normalize(req.sourceId)
           if sourceId.isEmpty then Left(Fail.IncorrectInput("source_id must not be empty"))
           else if !prefetchStore.isQueueable(sourceType, sourceId) then
             val status = prefetchStore.get(sourceType, sourceId).map(_.status.dbKey).getOrElse("pending")

--- a/src/main/scala/bgg/routes/FieldReduction.scala
+++ b/src/main/scala/bgg/routes/FieldReduction.scala
@@ -8,6 +8,11 @@ object FieldReduction:
   def apply(games: List[GameData], whitelist: Option[List[String]]): List[Json] =
     games.map(g => applyWhitelist(g.asJson, whitelist))
 
+  // Applies the whitelist to JSON that has already been built and enriched with
+  // extra fields (e.g. per-user collection metadata) not present on GameData.
+  def filterFields(games: List[Json], whitelist: Option[List[String]]): List[Json] =
+    games.map(applyWhitelist(_, whitelist))
+
   private def applyWhitelist(json: Json, whitelist: Option[List[String]]): Json =
     whitelist match
       case None => json

--- a/src/main/scala/bgg/routes/PrefetchTrigger.scala
+++ b/src/main/scala/bgg/routes/PrefetchTrigger.scala
@@ -13,14 +13,17 @@ trait PrefetchTrigger:
 
 class StepFunctionsTrigger(sfnClient: SfnClient, stateMachineArn: String) extends PrefetchTrigger with StrictLogging:
   def trigger(sourceType: SourceType, sourceId: String): Unit =
-    val input = Json.obj(
-      "sourceType" -> Json.fromString(sourceType.toPathSegment),
-      "sourceId" -> Json.fromString(sourceId)
-    ).noSpaces
+    val input = Json
+      .obj(
+        "sourceType" -> Json.fromString(sourceType.toPathSegment),
+        "sourceId" -> Json.fromString(sourceId)
+      )
+      .noSpaces
     val sanitizedId = sourceId.replaceAll("[^a-zA-Z0-9_-]", "_")
     val name = s"${sourceType.toPathSegment}-${sanitizedId}-${Instant.now().toEpochMilli}"
     sfnClient.startExecution(
-      StartExecutionRequest.builder()
+      StartExecutionRequest
+        .builder()
         .stateMachineArn(stateMachineArn)
         .name(name)
         .input(input)

--- a/src/test/scala/bgg/DynamoDbIntegrationSpec.scala
+++ b/src/test/scala/bgg/DynamoDbIntegrationSpec.scala
@@ -17,7 +17,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
 
 import java.time.Instant
-import scala.jdk.CollectionConverters.*
 
 class DynamoDbIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll:
 
@@ -182,3 +181,10 @@ class DynamoDbIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAf
 
       store.get(SourceType.Collection, "user1").get.status shouldBe PrefetchStatus.Completed
       store.get(SourceType.GeeKList, "user1").get.status shouldBe PrefetchStatus.Failed
+
+    "treat sourceId case-insensitively" in:
+      val store = DynamoDbPrefetchStatusStore(client, "prefetch-status")
+
+      store.set(SourceType.Collection, "MixedCase", PrefetchStatus.Completed)
+      // A differently-cased/whitespaced sourceId must resolve to the same normalized key.
+      store.get(SourceType.Collection, "  mixedcase ").map(_.status) shouldBe Some(PrefetchStatus.Completed)

--- a/src/test/scala/bgg/TestFixtures.scala
+++ b/src/test/scala/bgg/TestFixtures.scala
@@ -26,12 +26,14 @@ object TestFixtures:
 
   def stubClient(
       collectionResult: Either[Fail, List[GameId]] = Right(Nil),
+      collectionItems: Option[Either[Fail, List[CollectionItem]]] = None,
       geeklistResult: Either[Fail, List[GameId]] = Right(Nil),
       hotResult: Either[Fail, List[GameId]] = Right(Nil),
       gamesResult: Either[Fail, List[GameData]] = Right(Nil),
       playsResult: Either[Fail, List[PlayData]] = Right(Nil)
   ): BggClient = new BggClient:
-    def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = collectionResult
+    def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
+      collectionItems.getOrElse(collectionResult.map(_.map(id => CollectionItem(id, None))))
     def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = geeklistResult
     def fetchHotGames(): Either[Fail, List[GameId]] = hotResult
     def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = gamesResult

--- a/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
+++ b/src/test/scala/bgg/bggapi/BggXmlClientSpec.scala
@@ -5,7 +5,7 @@ import bgg.domain.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import sttp.client4.testing.{ResponseStub, SyncBackendStub}
-import sttp.model.{Header, StatusCode}
+import sttp.model.StatusCode
 
 class BggXmlClientSpec extends AnyWordSpec with Matchers:
 
@@ -29,9 +29,11 @@ class BggXmlClientSpec extends AnyWordSpec with Matchers:
     """<items totalitems="3">
       |  <item objecttype="thing" objectid="174430" subtype="boardgame">
       |    <name sortindex="1">Gloomhaven</name>
+      |    <status own="1" lastmodified="2022-03-15 08:21:49" />
       |  </item>
       |  <item objecttype="thing" objectid="167791" subtype="boardgame">
       |    <name sortindex="1">Terraforming Mars</name>
+      |    <status own="1" lastmodified="2020-01-02 05:45:43" />
       |  </item>
       |  <item objecttype="thing" objectid="169786" subtype="boardgame">
       |    <name sortindex="1">Scythe</name>
@@ -82,16 +84,6 @@ class BggXmlClientSpec extends AnyWordSpec with Matchers:
       |  </item>
       |</items>""".stripMargin
 
-  private val searchXml =
-    """<items total="2">
-      |  <item type="boardgame" id="174430">
-      |    <name type="primary" value="Gloomhaven"/>
-      |  </item>
-      |  <item type="boardgame" id="291457">
-      |    <name type="primary" value="Gloomhaven: Jaws of the Lion"/>
-      |  </item>
-      |</items>""".stripMargin
-
   "fetchCollection" should:
     "parse game IDs from collection XML" in:
       val backend = stubBackend(body = collectionXml)
@@ -99,7 +91,38 @@ class BggXmlClientSpec extends AnyWordSpec with Matchers:
 
       val result = client.fetchCollection("testuser")
 
-      result shouldBe Right(List(GameId(174430), GameId(167791), GameId(169786)))
+      result.map(_.map(_.id)) shouldBe Right(List(GameId(174430), GameId(167791), GameId(169786)))
+
+    "parse status/@lastmodified as a YYYY-MM-DD date, dropping the time" in:
+      val backend = stubBackend(body = collectionXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("testuser").toOption.get
+
+      result.find(_.id == GameId(174430)).flatMap(_.lastModified) shouldBe Some("2022-03-15")
+      result.find(_.id == GameId(167791)).flatMap(_.lastModified) shouldBe Some("2020-01-02")
+
+    "return None for lastModified when the item has no status element" in:
+      val backend = stubBackend(body = collectionXml)
+      val client = BggXmlClient(defaultConfig, backend)
+
+      val result = client.fetchCollection("testuser").toOption.get
+
+      result.find(_.id == GameId(169786)).flatMap(_.lastModified) shouldBe None
+
+    "return None for lastModified when status carries a blank date" in:
+      val blankDateXml =
+        """<items totalitems="1">
+          |  <item objecttype="thing" objectid="1" subtype="boardgame">
+          |    <name sortindex="1">Blank</name>
+          |    <status own="1" lastmodified="" />
+          |  </item>
+          |</items>""".stripMargin
+      val client = BggXmlClient(defaultConfig, stubBackend(body = blankDateXml))
+
+      val result = client.fetchCollection("testuser").toOption.get
+
+      result.head.lastModified shouldBe None
 
     "use correct URL with query params" in:
       var capturedUrl = ""

--- a/src/test/scala/bgg/bggapi/GameServiceSpec.scala
+++ b/src/test/scala/bgg/bggapi/GameServiceSpec.scala
@@ -57,7 +57,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
   private def stubClient(
       playsPage1: Either[Fail, List[PlayData]] = Right(Nil)
   ): BggClient = new BggClient:
-    def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+    def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
     def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
     def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
     def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -100,7 +100,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "paginate until empty page" in:
       var pageRequests = List.empty[Int]
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -123,7 +123,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "stop pagination on error after first page" in:
       var pageRequests = List.empty[Int]
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -155,7 +155,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "skip fetch when cache is fresh" in:
       var fetchCount = 0
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)
@@ -186,7 +186,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "cache result in request cache and serve from cache on second call" in:
       var fetchCount = 0
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] =
           fetchCount += 1
@@ -206,11 +206,70 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       result2.isRight shouldBe true
       fetchCount shouldBe 1
 
+  "resolveCollection" should:
+    "return games with their per-user lastmodified dates" in:
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
+          Right(List(CollectionItem(GameId(1), Some("2022-03-15")), CollectionItem(GameId(2), None)))
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
+          Right(List(testGame(1, "Catan"), testGame(2, "Pandemic")))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore, requestCache = MemoryRequestCache())
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolveCollection("alice").toOption.get
+      result.games.map(_.id) should contain allOf (GameId(1), GameId(2))
+      result.lastModifiedByGame shouldBe Map(GameId(1) -> "2022-03-15")
+
+    "serve dates from cache on subsequent calls without refetching" in:
+      var fetchCount = 0
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
+          fetchCount += 1
+          Right(List(CollectionItem(GameId(1), Some("2022-03-15"))))
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(testGame(1, "Catan")))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore, requestCache = MemoryRequestCache())
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      service.resolveCollection("bob"): Unit
+      val result = service.resolveCollection("bob").toOption.get
+
+      fetchCount shouldBe 1
+      result.lastModifiedByGame shouldBe Map(GameId(1) -> "2022-03-15")
+
+    "return empty dates when ids are cached but dates were never stored" in:
+      val requestCache = MemoryRequestCache()
+      requestCache.save("collection-ids:carol", List(1), 3600L, Instant.now())
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
+          fail("should not fetch when ids are cached")
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(testGame(1, "Catan")))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore, requestCache = requestCache)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolveCollection("carol").toOption.get
+      result.games.map(_.id) shouldBe List(GameId(1))
+      result.lastModifiedByGame shouldBe Map.empty
+
   "resolveGameIds (vectorize paths)" should:
     "vectorize a mature game with enough ratings" in:
       val matureGame = testGame(1, "Old Classic").copy(yearPublished = Some(2010), usersRated = Some(1000))
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(matureGame))
@@ -227,7 +286,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
     "not vectorize a mature game with too few ratings" in:
       val lowRated = testGame(2, "Obscure").copy(yearPublished = Some(2010), usersRated = Some(5))
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(lowRated))
@@ -245,7 +304,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       val currentYear = java.time.Year.now(java.time.ZoneOffset.UTC).getValue
       val newGame = testGame(3, "Brand New").copy(yearPublished = Some(currentYear), usersRated = Some(15))
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(newGame))
@@ -263,7 +322,7 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       val currentYear = java.time.Year.now(java.time.ZoneOffset.UTC).getValue
       val tooNew = testGame(4, "Too New").copy(yearPublished = Some(currentYear), usersRated = Some(3))
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(tooNew))

--- a/src/test/scala/bgg/bggapi/GameServiceSpec.scala
+++ b/src/test/scala/bgg/bggapi/GameServiceSpec.scala
@@ -265,6 +265,25 @@ class GameServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach:
       result.games.map(_.id) shouldBe List(GameId(1))
       result.lastModifiedByGame shouldBe Map.empty
 
+    "treat usernames case-insensitively when reading cached ids" in:
+      val requestCache = MemoryRequestCache()
+      // Stored under normalized (lowercase) key, as the fetch path would write it.
+      requestCache.save("collection-ids:dave", List(1), 3600L, Instant.now())
+      val client = new BggClient:
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
+          fail("should not fetch — a differently-cased username must hit the same cache key")
+        def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(List(testGame(1, "Catan")))
+        def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
+        def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
+
+      val caches = TestCacheProvider(gameCache, vectorStore, requestCache = requestCache)
+      val service = GameService(client, caches, 50, () => Instant.now())
+
+      val result = service.resolveCollection("  DaVe ").toOption.get
+      result.games.map(_.id) shouldBe List(GameId(1))
+
   "resolveGameIds (vectorize paths)" should:
     "vectorize a mature game with enough ratings" in:
       val matureGame = testGame(1, "Old Classic").copy(yearPublished = Some(2010), usersRated = Some(1000))

--- a/src/test/scala/bgg/lambda/BatchPreparerLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/BatchPreparerLogicSpec.scala
@@ -2,7 +2,6 @@ package bgg.lambda
 
 import bgg.TestFixtures.testGame
 import bgg.cache.MemoryGameCache
-import bgg.domain.GameId
 import io.circe.parser.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -17,7 +16,7 @@ class BatchPreparerLogicSpec extends AnyWordSpec with Matchers:
       val gameCache = MemoryGameCache()
       val logic = BatchPreparerLogic(gameCache)
       val ids = (1 to 650).toList
-      val input = s"""{"gameIds":${ids.mkString("[",",","]")},"sourceType":"collection","sourceId":"test"}"""
+      val input = s"""{"gameIds":${ids.mkString("[", ",", "]")},"sourceType":"collection","sourceId":"test"}"""
 
       val result = parse(logic.handle(input)).toOption.get
       val batches = result.asArray.get

--- a/src/test/scala/bgg/lambda/CollectionFetchLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/CollectionFetchLogicSpec.scala
@@ -1,13 +1,23 @@
 package bgg.lambda
 
-import bgg.TestFixtures.{stubClient, testGame}
-import bgg.bggapi.BggClient
+import bgg.TestFixtures.stubClient
+import bgg.cache.RequestCache
 import bgg.domain.*
 import io.circe.parser.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.time.Instant
+import scala.collection.mutable
+
 class CollectionFetchLogicSpec extends AnyWordSpec with Matchers:
+
+  private class MemoryRequestCache extends RequestCache:
+    val store: mutable.Map[String, String] = mutable.Map.empty
+    def load[T: io.circe.Decoder](key: String): Option[T] =
+      store.get(key).flatMap(json => io.circe.parser.decode[T](json).toOption)
+    def save[T: io.circe.Encoder](key: String, value: T, ttlSeconds: Long, now: Instant): Unit =
+      store(key) = io.circe.syntax.EncoderOps(value).asJson.noSpaces
 
   "CollectionFetchLogic" should:
 
@@ -21,6 +31,27 @@ class CollectionFetchLogicSpec extends AnyWordSpec with Matchers:
       ids shouldBe List(1, 2, 3)
       result.hcursor.downField("sourceType").as[String].toOption.get shouldBe "collection"
       result.hcursor.downField("sourceId").as[String].toOption.get shouldBe "testuser"
+
+    "cache collection ids and per-user lastmodified dates" in:
+      val client = stubClient(
+        collectionItems = Some(
+          Right(List(CollectionItem(GameId(1), Some("2022-03-15")), CollectionItem(GameId(2), None)))
+        )
+      )
+      val cache = MemoryRequestCache()
+      val logic = CollectionFetchLogic(client, retries = 6, requestCache = Some(cache))
+      val input = """{"sourceType":"collection","sourceId":"testuser"}"""
+
+      logic.handle(input): Unit
+
+      parse(cache.store("collection-ids:testuser")).toOption.get
+        .as[List[Int]]
+        .toOption
+        .get shouldBe List(1, 2)
+      parse(cache.store("collection-dates:testuser")).toOption.get
+        .as[Map[String, String]]
+        .toOption
+        .get shouldBe Map("1" -> "2022-03-15")
 
     "return game IDs for a geeklist" in:
       val client = stubClient(geeklistResult = Right(List(GameId(10), GameId(20))))

--- a/src/test/scala/bgg/lambda/GameFetchLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/GameFetchLogicSpec.scala
@@ -2,7 +2,7 @@ package bgg.lambda
 
 import bgg.TestFixtures.testGame
 import bgg.bggapi.BggClient
-import bgg.cache.{GameCache, MemoryGameCache, TestCacheProvider}
+import bgg.cache.{MemoryGameCache, TestCacheProvider}
 import bgg.domain.*
 import bgg.store.SqliteVectorStore
 import io.circe.parser.parse
@@ -37,10 +37,11 @@ class GameFetchLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
     "fetch games and return succeeded IDs" in:
       val games = List(testGame(1, "Catan"), testGame(2, "Pandemic"))
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
-        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(games.filter(g => ids.contains(g.id)))
+        def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
+          Right(games.filter(g => ids.contains(g.id)))
         def searchGames(query: String): Either[Fail, List[GameData]] = Right(Nil)
         def fetchPlays(username: String, page: Int): Either[Fail, List[PlayData]] = Right(Nil)
 
@@ -57,7 +58,7 @@ class GameFetchLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
       gameCache.save(game1, Instant.now())
 
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
@@ -75,7 +76,7 @@ class GameFetchLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
 
     "report failed sub-batches" in:
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
@@ -92,7 +93,7 @@ class GameFetchLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
 
     "throw BggRateLimitedException on rate limit" in:
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =
@@ -110,7 +111,7 @@ class GameFetchLogicSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
       gameCache.save(testGame(2, "Pandemic"), Instant.now())
 
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] =

--- a/src/test/scala/bgg/lambda/PlaysFetchPageLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/PlaysFetchPageLogicSpec.scala
@@ -1,10 +1,9 @@
 package bgg.lambda
 
 import bgg.TestFixtures.stubClient
-import bgg.bggapi.BggClient
-import bgg.cache.{NoOpPlaysCache, PlaysCache}
+import bgg.cache.PlaysCache
 import bgg.domain.*
-import bgg.prefetch.{PrefetchStatus, PrefetchStatusStore, SqlitePrefetchStatusStore}
+import bgg.prefetch.{PrefetchStatus, SqlitePrefetchStatusStore}
 import io.circe.parser.parse
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
@@ -173,7 +172,7 @@ class PlaysFetchPageLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
       val result = parse(logic.handle(input)).toOption.get
 
       result.hcursor.downField("done").as[Boolean].toOption.get shouldBe false
-      playsCache.store("judy") should contain allOf(play1, play2)
+      playsCache.store("judy") should contain allOf (play1, play2)
 
     "does not append empty list when all plays on page are already cached" in:
       val existingPlay = PlayData(100, GameId(100), "Catan", "2024-01-01", 1, 60, Nil)

--- a/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerLogicSpec.scala
@@ -99,7 +99,7 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
     "set status to Processing before completion" in:
       var statusDuringFetch: Option[PrefetchStatus] = None
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] =
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
           statusDuringFetch = prefetchStore.get(SourceType.Collection, username).map(_.status)
           Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
@@ -122,7 +122,7 @@ class PrefetchWorkerLogicSpec extends AnyWordSpec with Matchers with BeforeAndAf
     "set status to Completed on successful hot games prefetch" in:
       val games = List(testGame(1, "Catan"))
       val hotClient = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] = Right(Nil)
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] = Right(Nil)
         def fetchGeeklist(listId: String): Either[Fail, List[GameId]] = Right(Nil)
         def fetchHotGames(): Either[Fail, List[GameId]] = Right(List(GameId(1)))
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(games)

--- a/src/test/scala/bgg/lambda/PrefetchWorkerSpec.scala
+++ b/src/test/scala/bgg/lambda/PrefetchWorkerSpec.scala
@@ -96,7 +96,7 @@ class PrefetchWorkerSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
     "set status to Processing before fetching" in:
       var statusDuringFetch: Option[PrefetchStatus] = None
       val client = new BggClient:
-        def fetchCollection(username: String, retries: Int): Either[Fail, List[GameId]] =
+        def fetchCollection(username: String, retries: Int): Either[Fail, List[CollectionItem]] =
           statusDuringFetch = prefetchStore.get(SourceType.Collection, username).map(_.status)
           Right(Nil)
         def fetchGamesByIds(ids: List[GameId]): Either[Fail, List[GameData]] = Right(Nil)

--- a/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
+++ b/src/test/scala/bgg/routes/ApiEndpointsSpec.scala
@@ -85,6 +85,59 @@ class ApiEndpointsSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach
       val json = parseJson(response.body).getOrElse(Json.Null)
       json.asArray.map(_.size) shouldBe Some(2)
 
+    "include lastmodified date per game by default" in:
+      val client = stubClient(
+        collectionItems =
+          Some(Right(List(CollectionItem(GameId(1), Some("2022-03-15")), CollectionItem(GameId(2), None)))),
+        gamesResult = Right(List(testGame(1, "Catan"), testGame(2, "Pandemic")))
+      )
+      val endpoints = makeEndpoints(client)
+      val backend = makeBackend(endpoints)
+      val response = basicRequest
+        .get(uri"http://test/collection/testuser")
+        .response(asStringAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      val games = parseJson(response.body).getOrElse(Json.Null).asArray.get
+      val byId = games.map(g => g.hcursor.get[Int]("id").toOption.get -> g).toMap
+      byId(1).hcursor.get[String]("lastmodified").toOption shouldBe Some("2022-03-15")
+      byId(2).hcursor.get[Json]("lastmodified").toOption shouldBe Some(Json.Null)
+
+    "omit lastmodified when a field whitelist excludes it" in:
+      val client = stubClient(
+        collectionItems = Some(Right(List(CollectionItem(GameId(1), Some("2022-03-15"))))),
+        gamesResult = Right(List(testGame(1, "Catan")))
+      )
+      val endpoints = makeEndpoints(client)
+      val backend = makeBackend(endpoints)
+      val response = basicRequest
+        .get(uri"http://test/collection/testuser")
+        .header("Bgg-Field-Whitelist", "id,name")
+        .response(asStringAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      val json = parseJson(response.body).getOrElse(Json.Null).asArray.get.head
+      json.hcursor.keys.map(_.toList) shouldBe Some(List("id", "name"))
+
+    "include lastmodified when the whitelist requests it" in:
+      val client = stubClient(
+        collectionItems = Some(Right(List(CollectionItem(GameId(1), Some("2022-03-15"))))),
+        gamesResult = Right(List(testGame(1, "Catan")))
+      )
+      val endpoints = makeEndpoints(client)
+      val backend = makeBackend(endpoints)
+      val response = basicRequest
+        .get(uri"http://test/collection/testuser")
+        .header("Bgg-Field-Whitelist", "id,lastmodified")
+        .response(asStringAlways)
+        .send(backend)
+
+      response.code shouldBe StatusCode.Ok
+      val json = parseJson(response.body).getOrElse(Json.Null).asArray.get.head
+      json.hcursor.get[String]("lastmodified").toOption shouldBe Some("2022-03-15")
+
     "return 404 when user not found" in:
       val client = stubClient(collectionResult = Left(Fail.BggUserNotFound("ghost")))
       val endpoints = makeEndpoints(client)

--- a/src/test/scala/bgg/routes/FieldReductionSpec.scala
+++ b/src/test/scala/bgg/routes/FieldReductionSpec.scala
@@ -1,7 +1,6 @@
 package bgg.routes
 
 import bgg.domain.*
-import io.circe.Json
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/bgg/routes/HeaderFiltersSpec.scala
+++ b/src/test/scala/bgg/routes/HeaderFiltersSpec.scala
@@ -1,6 +1,5 @@
 package bgg.routes
 
-import bgg.domain.GameFilters
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import sttp.model.Header


### PR DESCRIPTION
## Summary

Three related changes, one per commit:

- **feat: per-user collection lastModified dates** - Each owned collection item's date is sourced from BGG's `status/@lastmodified` and surfaced as `lastmodified` on the `/collection` response. Dates are cached per-user (`collection-dates:<username>`) separately from the globally-shared `GameData` cache, so one user's dates never leak into another's collection or `/hot`. Adds `CollectionItem` / `CollectionResult` and `FieldReduction.filterFields` for the enriched JSON.

- **fix: normalize all username-derived cache keys to lowercase** - BGG usernames are case-insensitive, but only the plays cache lowercased its key (and never trimmed), so the same user in a different case could silently split across caches. A shared `CacheKeys` helper (trim + lowercase) now backs every key-construction site: the plays cache, collection/geeklist keys (built identically on the API read path and the Step Functions write path so they can't drift), the prefetch `statusKey`, and the `POST /prefetch` entry point.

- **build: PowerShell zip fallback**

## Testing

- Full suite: **324 tests pass** (includes LocalStack DynamoDB integration tests).
- `scalafmtCheckAll` clean.
- Added case-insensitivity tests: mixed-case/whitespace usernames resolve to the same normalized key on both the collection request cache and the prefetch status store.