### PR TITLE
perf: cut DynamoDB read cost on recommendations

### DIFF
--- a/src/main/scala/bgg/recommendation/RecommendationEngine.scala
+++ b/src/main/scala/bgg/recommendation/RecommendationEngine.scala
@@ -23,7 +23,7 @@ object RecommendationEngine extends StrictLogging:
       excludeIds: Set[GameId],
       filters: bgg.domain.GameFilters
   ): List[RecommendedGame] =
-    val allVectors = vectorStore.loadAll()
+    val allVectors = vectorStore.loadAllCached()
     logger.info(s"Loaded ${allVectors.size} vectors for recommendation scoring")
 
     val candidates = scoreCandidates(tasteVector, allVectors, excludeIds)
@@ -47,6 +47,10 @@ object RecommendationEngine extends StrictLogging:
         )
       }
 
+  // Batch size for filter hydration. Larger than most `limit` values so a single BatchGetItem usually
+  // fills the result; process windows lazily so we stop reading once `limit` matches are found.
+  private val FilterBatchSize = 100
+
   private def applyFiltersUntilLimit(
       sorted: List[RecommendedGame],
       gameCache: GameCache,
@@ -54,14 +58,20 @@ object RecommendationEngine extends StrictLogging:
       limit: Int
   ): List[RecommendedGame] =
     val filter = GameFilter.fromFilters(filters)
-    sorted.iterator
-      .filter { candidate =>
-        gameCache.load(candidate.gameId) match
-          case None =>
-            logger.debug(s"Game ${candidate.gameId.value} not in cache — skipping from recommendations")
-            false
-          case Some(game) =>
-            !filter.excludes(game)
+    // Hydrate candidates one batch at a time so we stop reading once `limit` matches are found,
+    // rather than loading every candidate's game up front.
+    sorted
+      .grouped(FilterBatchSize)
+      .flatMap { window =>
+        val games = gameCache.loadBatch(window.map(_.gameId)).map(g => g.id -> g).toMap
+        window.filter { candidate =>
+          games.get(candidate.gameId) match
+            case None =>
+              logger.debug(s"Game ${candidate.gameId.value} not in cache — skipping from recommendations")
+              false
+            case Some(game) =>
+              !filter.excludes(game)
+        }
       }
       .take(limit)
       .toList

--- a/src/main/scala/bgg/store/DynamoDbVectorStore.scala
+++ b/src/main/scala/bgg/store/DynamoDbVectorStore.scala
@@ -8,12 +8,26 @@ import io.circe.syntax.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.*
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 import scala.jdk.CollectionConverters.*
 
-class DynamoDbVectorStore(client: DynamoDbClient, tableName: String) extends VectorStore with StrictLogging:
+class DynamoDbVectorStore(
+    client: DynamoDbClient,
+    tableName: String,
+    clock: () => Instant = () => Instant.now(),
+    cacheTtl: Duration = Duration.ofMinutes(5)
+) extends VectorStore
+    with StrictLogging:
 
   private given Logger = logger
+
+  // Warm-container snapshot of the full corpus, refreshed at most once per cacheTtl. Vectors change
+  // rarely (only on game prefetch/fetch), so serving a slightly stale snapshot to recommendation
+  // scoring avoids a full-table Scan on every request. @volatile: Lambda may serve concurrent requests.
+  private case class Snapshot(vectors: List[StoredVector], takenAt: Instant):
+    def isFreshAt(now: Instant): Boolean = Duration.between(takenAt, now).compareTo(cacheTtl) < 0
+
+  @volatile private var snapshot: Option[Snapshot] = None
 
   def save(sv: StoredVector): Unit =
     val item = Map(
@@ -48,12 +62,32 @@ class DynamoDbVectorStore(client: DynamoDbClient, tableName: String) extends Vec
       }
       .getOrElse(Nil)
 
+  override def loadAllCached(): List[StoredVector] =
+    val now = clock()
+    snapshot match
+      case Some(current) if current.isFreshAt(now) =>
+        logger.debug(s"Serving ${current.vectors.size} vectors from warm snapshot")
+        current.vectors
+      case _ =>
+        val fresh = loadAll()
+        // Don't cache an empty result: loadAll returns Nil both for a genuinely empty corpus and for
+        // a swallowed Scan failure, and caching the latter would blank recommendations for the whole
+        // TTL. Retrying an empty scan next request is cheap.
+        if fresh.nonEmpty then snapshot = Some(Snapshot(fresh, now))
+        fresh
+
   @scala.annotation.tailrec
   private def scanAll(
       exclusiveStartKey: Option[java.util.Map[String, AttributeValue]],
       acc: List[StoredVector]
   ): List[StoredVector] =
-    val reqBuilder = ScanRequest.builder().tableName(tableName)
+    // Project only the attributes recommendation scoring needs; `updated_at` is dropped to cut bytes
+    // read (Scan bills by bytes, not rows). `name` is a DynamoDB reserved word, so alias it via #n.
+    val reqBuilder = ScanRequest
+      .builder()
+      .tableName(tableName)
+      .projectionExpression("game_id, #n, vector")
+      .expressionAttributeNames(Map("#n" -> "name").asJava)
     exclusiveStartKey.foreach(k => reqBuilder.exclusiveStartKey(k))
     val response = client.scan(reqBuilder.build())
     val page = response.items().asScala.flatMap(parseItem).toList
@@ -67,6 +101,7 @@ class DynamoDbVectorStore(client: DynamoDbClient, tableName: String) extends Vec
         gameId = GameId(item.get("game_id").n().toInt),
         name = item.get("name").s(),
         vector = GameVector(vec),
-        updatedAt = Instant.parse(item.get("updated_at").s())
+        // updated_at is absent from projected reads (scanAll); fall back to epoch when not present.
+        updatedAt = Option(item.get("updated_at")).map(a => Instant.parse(a.s())).getOrElse(Instant.EPOCH)
       )
     }

--- a/src/main/scala/bgg/store/VectorStore.scala
+++ b/src/main/scala/bgg/store/VectorStore.scala
@@ -11,3 +11,9 @@ trait VectorStore:
   def save(sv: StoredVector): Unit
   def load(id: GameId): Option[StoredVector]
   def loadAll(): List[StoredVector]
+
+  /** Like [[loadAll]] but may serve a recent in-memory snapshot to avoid repeated full-table scans. Recommendation
+    * scoring reads the whole corpus on every request; on a warm Lambda container this amortises the scan across
+    * invocations. Callers that need strong freshness should use [[loadAll]].
+    */
+  def loadAllCached(): List[StoredVector] = loadAll()

--- a/src/test/scala/bgg/DynamoDbIntegrationSpec.scala
+++ b/src/test/scala/bgg/DynamoDbIntegrationSpec.scala
@@ -5,9 +5,10 @@ import bgg.domain.*
 import bgg.prefetch.{DynamoDbPrefetchStatusStore, PrefetchStatus}
 import bgg.store.{DynamoDbVectorStore, StoredVector}
 import bgg.vector.GameVector
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, Canceled, Outcome}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.localstack.LocalStackContainer
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
 import org.testcontainers.utility.DockerImageName
@@ -25,7 +26,19 @@ class DynamoDbIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAf
 
   private var client: DynamoDbClient = _
 
+  // These tests need a real DynamoDB via LocalStack, which requires Docker. When Docker is
+  // unavailable (e.g. CI without a daemon), cancel each test rather than aborting the suite —
+  // a missing environment is not a test failure.
+  private lazy val dockerAvailable: Boolean =
+    try DockerClientFactory.instance().isDockerAvailable
+    catch case _: Throwable => false
+
+  override def withFixture(test: NoArgTest): Outcome =
+    if !dockerAvailable then Canceled("Docker not available — skipping DynamoDB integration tests")
+    else super.withFixture(test)
+
   override def beforeAll(): Unit =
+    if !dockerAvailable then return
     localstack.start()
     client = DynamoDbClient
       .builder()
@@ -44,7 +57,7 @@ class DynamoDbIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAf
 
   override def afterAll(): Unit =
     if client != null then client.close()
-    localstack.stop()
+    if dockerAvailable then localstack.stop()
 
   private def createTable(name: String, keyName: String, keyType: ScalarAttributeType): Unit =
     client.createTable(
@@ -140,6 +153,49 @@ class DynamoDbIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAf
       val store = DynamoDbVectorStore(client, "vectors")
       val all = store.loadAll()
       all.size should be >= 2
+
+    "loadAll projects the vector payload despite dropping updated_at" in:
+      val store = DynamoDbVectorStore(client, "vectors")
+      val v = GameVector(Vector.fill(155)(0.25))
+      store.save(StoredVector(GameId(300), "Projected Game", v, Instant.parse("2024-06-01T00:00:00Z")))
+
+      val loaded = store.loadAll().find(_.gameId == GameId(300))
+      loaded shouldBe defined
+      loaded.get.name shouldBe "Projected Game"
+      loaded.get.vector.values should have size 155
+      // updated_at is not projected by scanAll, so it falls back to EPOCH.
+      loaded.get.updatedAt shouldBe Instant.EPOCH
+
+    "loadAllCached serves a warm snapshot until the TTL expires" in:
+      var now = Instant.parse("2024-01-01T00:00:00Z")
+      val store = DynamoDbVectorStore(client, "vectors", () => now, java.time.Duration.ofMinutes(5))
+
+      val first = store.loadAllCached()
+      val firstSize = first.size
+
+      // Write a new vector; the cached snapshot must not reflect it before the TTL elapses.
+      store.save(StoredVector(GameId(400), "Fresh Game", GameVector(Vector.fill(155)(0.1)), now))
+      now = now.plusSeconds(60)
+      store.loadAllCached().size shouldBe firstSize
+
+      // Past the TTL the snapshot refreshes and picks up the new vector.
+      now = now.plusSeconds(5 * 60)
+      val refreshed = store.loadAllCached()
+      refreshed.size should be > firstSize
+      refreshed.map(_.gameId) should contain(GameId(400))
+
+    "loadAllCached does not cache an empty result so a transient failure never sticks" in:
+      // A swallowed Scan failure surfaces as an empty list, identical to a genuinely empty corpus.
+      // Caching it would blank recommendations for the whole TTL, so an empty scan must not be cached.
+      createTable("empty-vectors", "game_id", ScalarAttributeType.N)
+      val now = Instant.parse("2024-01-01T00:00:00Z")
+      val store = DynamoDbVectorStore(client, "empty-vectors", () => now, java.time.Duration.ofMinutes(5))
+
+      store.loadAllCached() shouldBe empty
+
+      // A vector written after the empty scan is visible immediately, proving nothing was cached.
+      store.save(StoredVector(GameId(500), "Late Game", GameVector(Vector.fill(155)(0.2)), now))
+      store.loadAllCached().map(_.gameId) should contain(GameId(500))
 
   "DynamoDbPrefetchStatusStore" should:
     "set and get prefetch status" in:


### PR DESCRIPTION
## Problem

A handful of users already breach the DynamoDB free tier on reads. Root cause: `RecommendationEngine` called `vectorStore.loadAll()` on every `POST /recommendations/from-games`, running a full-table Scan per request. DynamoDB bills Scan by bytes read, and each vector row holds a ~2-4KB JSON array of doubles, so re-reading the whole corpus each call dominated read cost. A secondary N+1 issued one GetItem per candidate when filters were active.

## Changes

1. **Warm-container vector cache.** `VectorStore.loadAllCached()` serves an in-memory snapshot with a 5-minute TTL; `RecommendationEngine` uses it. The Lambda holds the store in a `private val`, so warm invocations reuse the snapshot and amortise the scan. Empty results are not cached, so a swallowed Scan failure (`loadAll` returns `Nil` on error) never blanks recommendations for the whole TTL.
2. **Batched filter hydration.** `applyFiltersUntilLimit` reads candidates via `gameCache.loadBatch` in windows of 100, evaluated lazily so it stops once `limit` matches are found. Replaces the per-candidate GetItem.
3. **Scan projection.** The vector Scan projects only `game_id`, `name`, `vector`, dropping `updated_at` to cut bytes read; `parseItem` falls back to `Instant.EPOCH` when the attribute is absent.

## Tests

343 tests pass. Added integration coverage for the TTL snapshot, the projection fallback, and the empty-result guard.

## Follow-up (not in this PR)

Precompute recommendations off the request path if 1-3 prove insufficient. Not warranted at current scale.